### PR TITLE
Use single nearest neighbor method instead of iterator

### DIFF
--- a/nblast-rs/src/lib.rs
+++ b/nblast-rs/src/lib.rs
@@ -59,7 +59,7 @@
 //! A pre-calculated table of point match scores can be converted into a function with [table_to_fn](fn.table_to_fn.html).
 use nalgebra::base::{Matrix3, Unit, Vector3};
 use rstar::primitives::PointWithData;
-use rstar::RTree;
+use rstar::{PointDistance, RTree};
 use std::collections::{HashMap, HashSet};
 
 #[cfg(feature = "parallel")]
@@ -552,9 +552,8 @@ impl TargetNeuron for RStarTangentsAlphas {
         alpha: Option<Precision>,
     ) -> DistDot {
         self.rtree
-            .nearest_neighbor_iter_with_distance(point)
-            .next()
-            .map(|(element, dist2)| {
+            .nearest_neighbor(point)
+            .map(|element| {
                 let ta = self.tangents_alphas[element.data];
                 let raw_dot = ta.tangent.dot(tangent).abs();
                 let dot = match alpha {
@@ -562,7 +561,7 @@ impl TargetNeuron for RStarTangentsAlphas {
                     None => raw_dot,
                 };
                 DistDot {
-                    dist: dist2.sqrt(),
+                    dist: element.distance_2(point).sqrt(),
                     dot,
                 }
             })


### PR DESCRIPTION
```
$ cargo benchcmp master single-nn --threshold 5
 name                         master ns/iter  single-nn ns/iter  diff ns/iter   diff %  speedup
 bench_all_to_all_parallel    19,344,342      15,956,802           -3,387,540  -17.51%   x 1.21
 bench_all_to_all_serial      165,671,156     137,606,946         -28,064,210  -16.94%   x 1.20
 bench_arena_query            601,230         433,101                -168,129  -27.96%   x 1.39
 bench_arena_query_geom       1,102,436       858,982                -243,454  -22.08%   x 1.28
 bench_arena_query_norm       589,876         456,101                -133,775  -22.68%   x 1.29
 bench_arena_query_norm_geom  1,098,293       869,965                -228,328  -20.79%   x 1.26
 bench_query                  592,841         432,123                -160,718  -27.11%   x 1.37
```