### PR TITLE
Support for multiple non-matching sets

### DIFF
--- a/.github/workflows/nblast-py.yaml
+++ b/.github/workflows/nblast-py.yaml
@@ -7,22 +7,24 @@ defaults:
     working-directory: nblast-py
 
 jobs:
-
   lint:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.x'
-      - run: pip install $(grep -E '^(black|flake8|mypy|isort)' requirements.txt)
+          python-version: "3.x"
+      - run: pip install $(grep -E '^(ruff|mypy)' requirements.txt)
       - run: make lint
 
   test:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -71,7 +73,7 @@ jobs:
           toolchain: stable
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - uses: PyO3/maturin-action@v1
         with:
           manylinux: auto

--- a/examples/bench_fib250.py
+++ b/examples/bench_fib250.py
@@ -9,6 +9,7 @@ import os
 from tqdm import tqdm
 import pandas as pd
 import numpy as np
+import pooch
 
 from pynblast import NblastArena, ScoreMatrix
 
@@ -19,7 +20,7 @@ here = Path(__file__).resolve().parent
 
 
 def get_threads():
-    val = os.environ.get("NBLAST_THREADS", 0) or 0
+    val = os.environ.get("NBLAST_THREADS", "0")
     try:
         return int(val)
     except ValueError:
@@ -32,11 +33,13 @@ THREADS = get_threads()
 logger.warning("Running with THREADS = %s", THREADS)
 
 URL_PREFIX = "https://github.com/clbarnes/nblast-rs/files"
-SCORES_NAME = "fib250.aba.csv.zip"
 
-SCORES_URL = f"{URL_PREFIX}/4567582/{SCORES_NAME}"
 
-SCORES_FPATH = here / SCORES_NAME
+def get_scores_path() -> Path:
+    SCORES_NAME = "fib250.aba.csv.zip"
+
+    SCORES_URL = f"{URL_PREFIX}/4567582/{SCORES_NAME}"
+    return Path(pooch.retrieve(SCORES_URL, None))
 
 
 def df_to_pt_tan_a(df):
@@ -49,10 +52,8 @@ def df_to_pt_tan_a(df):
 def ingest_dotprops():
     DOTPROPS_NAME = "fib250.csv.zip"
     DOTPROPS_URL = f"{URL_PREFIX}/4567531/{DOTPROPS_NAME}"
-    DOTPROPS_FPATH = here / DOTPROPS_NAME
 
-    if not DOTPROPS_FPATH.is_file():
-        raise ValueError(f"Download necessary data from\n\t{DOTPROPS_URL}")
+    DOTPROPS_FPATH = Path(pooch.retrieve(url=DOTPROPS_URL, known_hash=None))
 
     with zf.ZipFile(DOTPROPS_FPATH) as z:
         with z.open(DOTPROPS_FPATH.name[:-4]) as f:

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -4,4 +4,4 @@ jupyter
 pynblast
 numpy
 tqdm
-
+pooch

--- a/nblast-js/src/lib.rs
+++ b/nblast-js/src/lib.rs
@@ -82,14 +82,14 @@ impl NblastArena {
         })
     }
 
-    #[wasm_bindgen(js_name="addPoints")]
+    #[wasm_bindgen(js_name = "addPoints")]
     pub fn add_points(&mut self, flat_points: &[f64]) -> JsResult<usize> {
         let points = flat_to_array3(flat_points);
         let neuron = RStarTangentsAlphas::new(points, self.k).map_err(JsError::new)?;
         Ok(self.arena.add_neuron(neuron))
     }
 
-    #[wasm_bindgen(js_name="addPointsTangentsAlphas")]
+    #[wasm_bindgen(js_name = "addPointsTangentsAlphas")]
     pub fn add_points_tangents_alphas(
         &mut self,
         flat_points: &[f64],
@@ -110,7 +110,7 @@ impl NblastArena {
         Ok(self.arena.add_neuron(neuron))
     }
 
-    #[wasm_bindgen(js_name="queryTarget")]
+    #[wasm_bindgen(js_name = "queryTarget")]
     pub fn query_target(
         &self,
         query_idx: NeuronIdx,
@@ -125,7 +125,7 @@ impl NblastArena {
             .query_target(query_idx, target_idx, normalize, &sym, use_alpha))
     }
 
-    #[wasm_bindgen(js_name="queriesTargets")]
+    #[wasm_bindgen(js_name = "queriesTargets")]
     pub fn queries_targets(
         &self,
         query_idxs: &[NeuronIdx],
@@ -148,7 +148,7 @@ impl NblastArena {
         Ok(serde_wasm_bindgen::to_value(&out)?)
     }
 
-    #[wasm_bindgen(js_name="allVAll")]
+    #[wasm_bindgen(js_name = "allVAll")]
     pub fn all_v_all(
         &self,
         normalize: bool,

--- a/nblast-js/src/lib.rs
+++ b/nblast-js/src/lib.rs
@@ -56,7 +56,7 @@ fn convert_multi_output(
 ) -> HashMap<NeuronIdx, HashMap<NeuronIdx, Precision>> {
     let mut out: HashMap<NeuronIdx, HashMap<NeuronIdx, f64>> = HashMap::default();
     for ((q, t), v) in result.drain() {
-        out.entry(q).or_insert_with(HashMap::default).insert(t, v);
+        out.entry(q).or_default().insert(t, v);
     }
     out
 }
@@ -171,8 +171,7 @@ pub fn make_flat_tangents_alphas(flat_points: &[f64], k: usize) -> JsResult<Floa
     for (idx, val) in neuron
         .tangents()
         .into_iter()
-        .map(|n| [n[0], n[1], n[2]])
-        .flatten()
+        .flat_map(|n| [n[0], n[1], n[2]])
         .chain(neuron.alphas().into_iter())
         .enumerate()
     {

--- a/nblast-py/Cargo.toml
+++ b/nblast-py/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 pyo3 = { version = "0.18.2", features = ["extension-module"] }
 neurarbor = "0.2.0"
 nblast = { path = "../nblast-rs", version = "^0.5.0", features = ["parallel"] }
+numpy = "0.18"
 
 [lib]
 name = "pynblast"

--- a/nblast-py/Cargo.toml
+++ b/nblast-py/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.rst"
 edition = "2018"
 
 [dependencies]
-pyo3 = { version = "0.17.2", features = ["extension-module"] }
+pyo3 = { version = "0.18.2", features = ["extension-module"] }
 neurarbor = "0.2.0"
 nblast = { path = "../nblast-rs", version = "^0.5.0", features = ["parallel"] }
 

--- a/nblast-py/Makefile
+++ b/nblast-py/Makefile
@@ -52,12 +52,12 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr .pytest_cache
 
 fmt:
-	black $(PY_PATHS)
+	ruff format $(PY_PATHS)
 	cargo fmt
 
 lint: ## check style with flake8
-	flake8 $(PY_PATHS)
-	black --check $(PY_PATHS)
+	ruff check $(PY_PATHS)
+	ruff format --check $(PY_PATHS)
 
 test: ## run tests quickly with the default Python
 	maturin develop

--- a/nblast-py/pyproject.toml
+++ b/nblast-py/pyproject.toml
@@ -1,7 +1,10 @@
 [project]
 name = "pynblast"
-dependencies = [
-  "numpy"
+description = "NBLAST neuron morphology comparison in python (over rust)"
+readme = "README.rst"
+requires-python = ">=3.9"
+authors = [
+  {name = "Chris L. Barnes", email = "chrislloydbarnes@gmail.com"}
 ]
 license = { text = "MIT" }
 
@@ -12,11 +15,29 @@ classifiers = [
   "Natural Language :: English",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+]
+dependencies = [
+  "numpy>=1.21.0"
 ]
 
+[project.urls]
+homepage = "https://pypi.org/project/pynblast/"
+documentation = "https://pynblast.readthedocs.io/"
+repository = "https://github.com/clbarnes/nblast-rs/nblast-py"
+
 [build-system]
-requires = ["maturin>=0.13,<0.14"]
+requires = ["maturin==0.14", "numpy>=1.21"]
 build-backend = "maturin"
 
 [tool.maturin]
 python-source = "python"
+
+[tool.mypy]
+ignore_missing_imports = true
+plugins = ["numpy.typing.mypy_plugin"]
+python_version = "3.9"
+
+[tool.ruff]
+extend-exclude = ["docs"]
+target-version = "py39"

--- a/nblast-py/python/pynblast/arena.py
+++ b/nblast-py/python/pynblast/arena.py
@@ -19,6 +19,7 @@ class NblastArena:
         dist_bins: List[float],
         dot_bins: List[float],
         score_mat: np.ndarray,
+        use_alpha: bool,
         threads: Optional[int] = DEFAULT_THREADS,
         k=DEFAULT_K,
     ):
@@ -41,19 +42,21 @@ class NblastArena:
 
         ``k`` gives the number of points to use when calculating tangents.
 
-        ``threads`` sets the default number of threads to use.
-        If `threads` < 0 (default), use the class' ``threads`` attribute (default 0).
+        ``threads`` sets the number of threads to use.
         If it is 0, use the number of threads available.
         If it is > 0, use at most that many.
         If it is ``None``, run in serial.
         """
+        self.use_alpha = use_alpha
         self.threads = threads
         self.k = k
 
         if score_mat.shape != (len(dist_bins) - 1, len(dot_bins) - 1):
             raise ValueError("Bin thresholds do not match score matrix")
         score_vec = score_mat.flatten().tolist()
-        self._impl = ArenaWrapper(dist_bins, dot_bins, score_vec, self.k)
+        self._impl = ArenaWrapper(
+            dist_bins, dot_bins, score_vec, self.k, self.use_alpha, self.threads
+        )
 
     def add_points(self, points: np.ndarray) -> Idx:
         """Add an Nx3 point cloud to the arena representing a neuron.
@@ -62,32 +65,39 @@ class NblastArena:
         Returns an integer index which is used to refer to that neuron later,
         for queries etc..
         """
+        points = np.asarray(points)
         if points.ndim != 2 or points.shape[1] != 3:
             raise ValueError("Points must have shape Nx3")
         return self._impl.add_points(points.tolist())
 
     def add_points_tangents_alphas(
-        self, points: np.ndarray, tangents: np.ndarray, alphas: np.ndarray
+        self, points: np.ndarray, tangents: np.ndarray, alphas: Optional[np.ndarray],
     ) -> Idx:
         """Add an Nx3 point cloud representing a neuron, with pre-calculated tangents.
-        Tangents are assumed to be unit-length and in the same order as the points.
+        Tangents must be unit-length and in the same order as the points.
+        If this arena is not using alphas, you can give `None` for the `alphas` argument.
 
         Returns an integer index which is used to refer to that neuron later.
         """
+        points = np.asarray(points)
+        tangents = np.asarray(tangents)
+
         if points.shape != tangents.shape or points.ndim != 2 or points.shape[1] != 3:
             raise ValueError("Points and tangents must have the same shape, Nx3")
 
-        return self._impl.add_points_tangents_alphas(
-            points.tolist(), tangents.tolist(), list(alphas)
-        )
-
-    def _parse_threads(self, threads: Optional[int]) -> Optional[int]:
-        if threads is None:
-            return None
-        elif threads < 0:
-            return self.threads
+        if alphas is None:
+            if self.use_alpha:
+                raise ValueError("Alpha values not given, but this NblastArena uses alpha weighting")
+            else:
+                alphas = np.full(len(points), 1.0)
         else:
-            return int(threads)
+            alphas = np.asarray(alphas)
+            if alphas.shape != (len(points), ):
+                raise ValueError("Alphas must be 1D and have same length as points")
+
+        return self._impl.add_points_tangents_alphas(
+            points.tolist(), tangents.tolist(), alphas.tolist()
+        )
 
     def query_target(
         self,
@@ -95,7 +105,6 @@ class NblastArena:
         target_idx: Idx,
         normalize: bool = False,
         symmetry: Optional[Symmetry] = None,
-        use_alpha: bool = False,
     ) -> float:
         """Query one neuron against another,
         using the indices generated when they were added.
@@ -108,9 +117,7 @@ class NblastArena:
         operation commutative/ symmetric
         (see the ``Symmetry`` enum for available functions).
         """
-        out = self._impl.query_target(
-            query_idx, target_idx, bool(normalize), symmetry, use_alpha
-        )
+        out = self._impl.query_target(query_idx, target_idx, bool(normalize), symmetry)
         return raise_if_none(out, query_idx, target_idx)
 
     def queries_targets(
@@ -119,8 +126,6 @@ class NblastArena:
         target_idxs: List[Idx],
         normalize: bool = False,
         symmetry: Optional[Symmetry] = None,
-        use_alpha: bool = False,
-        threads: Optional[int] = -1,
         max_centroid_dist: Optional[float] = None,
     ) -> Dict[Tuple[Idx, Idx], float]:
         """Query all combinations of some query neurons against some target neurons.
@@ -132,14 +137,11 @@ class NblastArena:
         ``normalize`` and ``symmetry``.
         See the ``__init__`` method for more details on ``threads``.
         """
-        threads = self._parse_threads(threads)
         return self._impl.queries_targets(
             query_idxs,
             target_idxs,
             bool(normalize),
             symmetry,
-            use_alpha,
-            threads,
             max_centroid_dist,
         )
 
@@ -147,8 +149,6 @@ class NblastArena:
         self,
         normalize=False,
         symmetry=None,
-        use_alpha: bool = False,
-        threads: Optional[int] = -1,
         max_centroid_dist: Optional[float] = None,
     ) -> Dict[Tuple[Idx, Idx], float]:
         """Query all loaded neurons against each other.
@@ -160,10 +160,7 @@ class NblastArena:
         ``normalize`` and ``symmetry``.
         See the ``__init__`` method for more details on ``threads``.
         """
-        threads = self._parse_threads(threads)
-        return self._impl.all_v_all(
-            bool(normalize), symmetry, use_alpha, threads, max_centroid_dist
-        )
+        return self._impl.all_v_all(bool(normalize), symmetry, max_centroid_dist)
 
     def __len__(self) -> int:
         return self._impl.len()
@@ -172,12 +169,12 @@ class NblastArena:
         for idx in range(len(self)):
             yield Idx(idx)
 
-    def self_hit(self, idx, use_alpha: bool = False) -> float:
+    def self_hit(self, idx) -> float:
         """Get the raw score for querying the given neuron against itself.
 
-        N.B. this is much faster that ``arena.query_target(n, n)``.
+        N.B. this is much faster than ``arena.query_target(n, n)``.
         """
-        out = self._impl.self_hit(idx, use_alpha)
+        out = self._impl.self_hit(idx)
         return raise_if_none(out, idx)
 
     def points(self, idx) -> np.ndarray:

--- a/nblast-py/python/pynblast/arena.py
+++ b/nblast-py/python/pynblast/arena.py
@@ -101,9 +101,7 @@ class NblastArena:
             if alphas.shape != (len(points),):
                 raise ValueError("Alphas must be 1D and have same length as points")
 
-        return self._impl.add_points_tangents_alphas(
-            points, tangents, alphas
-        )
+        return self._impl.add_points_tangents_alphas(points, tangents, alphas)
 
     def query_target(
         self,

--- a/nblast-py/python/pynblast/arena.py
+++ b/nblast-py/python/pynblast/arena.py
@@ -68,7 +68,7 @@ class NblastArena:
         points = np.asarray(points)
         if points.ndim != 2 or points.shape[1] != 3:
             raise ValueError("Points must have shape Nx3")
-        return self._impl.add_points(points.tolist())
+        return self._impl.add_points(points)
 
     def add_points_tangents_alphas(
         self,
@@ -102,7 +102,7 @@ class NblastArena:
                 raise ValueError("Alphas must be 1D and have same length as points")
 
         return self._impl.add_points_tangents_alphas(
-            points.tolist(), tangents.tolist(), alphas.tolist()
+            points, tangents, alphas
         )
 
     def query_target(

--- a/nblast-py/python/pynblast/arena.py
+++ b/nblast-py/python/pynblast/arena.py
@@ -19,7 +19,7 @@ class NblastArena:
         dist_bins: List[float],
         dot_bins: List[float],
         score_mat: np.ndarray,
-        use_alpha: bool,
+        use_alpha: bool = False,
         threads: Optional[int] = DEFAULT_THREADS,
         k=DEFAULT_K,
     ):

--- a/nblast-py/python/pynblast/arena.py
+++ b/nblast-py/python/pynblast/arena.py
@@ -71,11 +71,15 @@ class NblastArena:
         return self._impl.add_points(points.tolist())
 
     def add_points_tangents_alphas(
-        self, points: np.ndarray, tangents: np.ndarray, alphas: Optional[np.ndarray],
+        self,
+        points: np.ndarray,
+        tangents: np.ndarray,
+        alphas: Optional[np.ndarray],
     ) -> Idx:
         """Add an Nx3 point cloud representing a neuron, with pre-calculated tangents.
         Tangents must be unit-length and in the same order as the points.
-        If this arena is not using alphas, you can give `None` for the `alphas` argument.
+        If this arena is not using alphas,
+        you can give `None` for the `alphas` argument.
 
         Returns an integer index which is used to refer to that neuron later.
         """
@@ -87,12 +91,14 @@ class NblastArena:
 
         if alphas is None:
             if self.use_alpha:
-                raise ValueError("Alpha values not given, but this NblastArena uses alpha weighting")
+                raise ValueError(
+                    "Alpha values not given, but this NblastArena uses alpha weighting"
+                )
             else:
                 alphas = np.full(len(points), 1.0)
         else:
             alphas = np.asarray(alphas)
-            if alphas.shape != (len(points), ):
+            if alphas.shape != (len(points),):
                 raise ValueError("Alphas must be 1D and have same length as points")
 
         return self._impl.add_points_tangents_alphas(

--- a/nblast-py/python/pynblast/pynblast.pyi
+++ b/nblast-py/python/pynblast/pynblast.pyi
@@ -73,5 +73,4 @@ def build_score_matrix(
     dot_inner_bounds: Optional[List[float]],
     max_matching_pairs: Optional[int],
     max_nonmatching_pairs: Optional[int],
-) -> Tuple[List[float], List[float], List[float]]:
-    ...
+) -> Tuple[List[float], List[float], List[float]]: ...

--- a/nblast-py/python/pynblast/pynblast.pyi
+++ b/nblast-py/python/pynblast/pynblast.pyi
@@ -1,6 +1,6 @@
 """Type stubs for classes to be used directly from pynblast"""
 from __future__ import annotations
-from typing import List, Optional, Tuple
+from typing import List, Optional, Set, Tuple
 from .util import Idx
 
 class ResamplingArbor:
@@ -24,6 +24,8 @@ class ArenaWrapper:
         dot_thresholds: list[float],
         cells: list[float],
         k: int,
+        use_alpha: bool,
+        threads: Optional[int],
     ) -> None: ...
     def add_points(self, points: list[list[float]]) -> Idx: ...
     def add_points_tangents_alphas(
@@ -35,7 +37,6 @@ class ArenaWrapper:
         target_idx: Idx,
         normalize: bool,
         symmetry: Optional[str],
-        use_alpha: bool,
     ) -> Optional[float]: ...
     def queries_targets(
         self,
@@ -43,21 +44,34 @@ class ArenaWrapper:
         target_idxs: list[Idx],
         normalize: bool,
         symmetry: Optional[str],
-        use_alpha: bool,
-        threads: Optional[int],
         max_centroid_dist: Optional[float],
     ) -> dict[tuple[Idx, Idx], float]: ...
     def all_v_all(
         self,
         normalize: bool,
         symmetry: Optional[str],
-        use_alpha: bool,
-        threads: Optional[int],
         max_centroid_dist: Optional[float],
     ) -> dict[tuple[Idx, Idx], float]: ...
     def len(self) -> int: ...
     def is_empty(self) -> bool: ...
-    def self_hit(self, idx: Idx, use_alpha: bool) -> Optional[float]: ...
+    def self_hit(self, idx: Idx) -> Optional[float]: ...
     def points(self, idx: Idx) -> Optional[list[list[float]]]: ...
     def tangents(self, idx: Idx) -> Optional[list[list[float]]]: ...
     def alphas(self, idx: Idx) -> Optional[list[float]]: ...
+
+def build_score_matrix(
+    points: List[List[List[float]]],
+    k: int,
+    seed: int,
+    use_alpha: bool,
+    threads: Optional[int],
+    matching_sets: List[List[int]],
+    nonmatching_sets: Optional[List[List[int]]],
+    dist_n_bins: Optional[int],
+    dist_inner_bounds: Optional[List[float]],
+    dot_n_bins: Optional[int],
+    dot_inner_bounds: Optional[List[float]],
+    max_matching_pairs: Optional[int],
+    max_nonmatching_pairs: Optional[int],
+) -> Tuple[List[float], List[float], List[float]]:
+    ...

--- a/nblast-py/python/pynblast/pynblast.pyi
+++ b/nblast-py/python/pynblast/pynblast.pyi
@@ -64,7 +64,6 @@ def build_score_matrix(
     k: int,
     seed: int,
     use_alpha: bool,
-    threads: Optional[int],
     matching_sets: List[List[int]],
     nonmatching_sets: Optional[List[List[int]]],
     dist_n_bins: Optional[int],
@@ -73,4 +72,5 @@ def build_score_matrix(
     dot_inner_bounds: Optional[List[float]],
     max_matching_pairs: Optional[int],
     max_nonmatching_pairs: Optional[int],
+    threads: Optional[int],
 ) -> Tuple[List[float], List[float], List[float]]: ...

--- a/nblast-py/python/pynblast/pynblast.pyi
+++ b/nblast-py/python/pynblast/pynblast.pyi
@@ -1,6 +1,6 @@
 """Type stubs for classes to be used directly from pynblast"""
 from __future__ import annotations
-from typing import List, Optional, Set, Tuple
+from typing import List, Optional, Tuple
 from .util import Idx
 
 class ResamplingArbor:

--- a/nblast-py/python/pynblast/smat_builder.py
+++ b/nblast-py/python/pynblast/smat_builder.py
@@ -1,0 +1,85 @@
+from typing import List, Optional, Set, Union
+
+import numpy as np
+
+from pynblast.arena import DEFAULT_K, DEFAULT_THREADS
+from .pynblast import build_score_matrix
+
+
+class ScoreMatrixBuilder:
+    def __init__(self, seed: int, k: int = DEFAULT_K, use_alpha: bool = False):
+        self.seed = seed
+        self.k = k
+        self.use_alpha = use_alpha
+
+        self.neurons: List[List[List[float]]] = []
+
+        self.matching_sets: List[List[int]] = []
+        self.nonmatching_sets: Optional[List[List[int]]] = None
+
+        self.dist_n_bins: Optional[int] = None
+        self.dist_inner_bounds: Optional[List[float]] = None
+        self.dot_n_bins: Optional[int] = None
+        self.dot_inner_bounds: Optional[List[float]] = None
+
+        self.max_matching_pairs: Optional[int] = None
+        self.max_nonmatching_pairs: Optional[int] = None
+
+    def add_neuron(self, points: np.ndarray) -> int:
+        points = np.asarray(points)
+        if len(points) < self.k:
+            raise ValueError(f"Neuron does not have enough points (needs {self.k})")
+        if points.ndim != 2 or points.shape[1] != 3:
+            raise ValueError("Not an Nx3 array")
+        idx = len(self.neurons)
+        self.neurons.append(points.tolist())
+        return idx
+
+    def add_matching_set(self, ids: Set[int]):
+        self.matching_sets.append(sorted(ids))
+
+    def add_nonmatching_set(self, ids: Set[int]):
+        if self.nonmatching_sets is None:
+            self.nonmatching_sets = []
+        self.nonmatching_sets.append(sorted(ids))
+
+    def set_dist_bins(self, bins: Union[int, List[float]]):
+        """Number of bins, or list of inner boundaries of bins"""
+        if isinstance(bins, int):
+            self.dist_n_bins = bins
+            self.dist_inner_bounds = None
+        else:
+            self.dist_inner_bounds = sorted(bins)
+            self.dist_n_bins = None
+
+    def set_dot_bins(self, bins: Union[int, List[float]]):
+        """Number of bins, or list of inner boundaries of bins"""
+        if isinstance(bins, int):
+            self.dot_n_bins = bins
+            self.dot_inner_bounds = None
+        else:
+            self.dot_inner_bounds = sorted(bins)
+            self.dot_n_bins = None
+
+    def set_max_pairs(self, matching: Optional[int], nonmatching: Optional[int]):
+        self.max_matching_pairs = matching
+        self.max_nonmatching_pairs = nonmatching
+
+    def build(self, threads: Optional[int] = DEFAULT_THREADS):
+        dist_bins, dot_bins, cells = build_score_matrix(
+            self.neurons,
+            self.k,
+            self.seed,
+            self.use_alpha,
+            threads,
+            self.matching_sets,
+            self.nonmatching_sets,
+            self.dist_n_bins,
+            self.dot_inner_bounds,
+            self.dot_n_bins,
+            self.dot_inner_bounds,
+            self.max_matching_pairs,
+            self.max_nonmatching_pairs,
+        )
+        values = np.array(cells).reshape((len(dist_bins), len(dot_bins)))
+        return dist_bins, dot_bins, values

--- a/nblast-py/python/pynblast/smat_builder.py
+++ b/nblast-py/python/pynblast/smat_builder.py
@@ -71,7 +71,6 @@ class ScoreMatrixBuilder:
             self.k,
             self.seed,
             self.use_alpha,
-            threads,
             self.matching_sets,
             self.nonmatching_sets,
             self.dist_n_bins,
@@ -80,6 +79,7 @@ class ScoreMatrixBuilder:
             self.dot_inner_bounds,
             self.max_matching_pairs,
             self.max_nonmatching_pairs,
+            threads,
         )
         values = np.array(cells).reshape((len(dist_bins), len(dot_bins)))
         return dist_bins, dot_bins, values

--- a/nblast-py/requirements.txt
+++ b/nblast-py/requirements.txt
@@ -16,7 +16,7 @@ pytest-benchmark==4.0.0
 pip==23.0.1
 wheel==0.38.4
 watchdog==2.3.1
-flake8==6.0.0
+ruff
 coverage==7.2.1
 Sphinx==6.1.3
 black==23.1

--- a/nblast-py/requirements.txt
+++ b/nblast-py/requirements.txt
@@ -19,5 +19,4 @@ watchdog==2.3.1
 ruff
 coverage==7.2.1
 Sphinx==6.1.3
-black==23.1
 mypy==1.1.1

--- a/nblast-py/setup.cfg
+++ b/nblast-py/setup.cfg
@@ -1,3 +1,0 @@
-[flake8]
-exclude = docs
-max-line-length = 88

--- a/nblast-py/src/lib.rs
+++ b/nblast-py/src/lib.rs
@@ -363,6 +363,12 @@ fn make_neurons_many(
     }
 }
 
+fn inner_bounds_to_binlookup(mut v: Vec<Precision>) -> BinLookup<Precision> {
+    v.insert(0, NEG_INFINITY);
+    v.push(INFINITY);
+    BinLookup::new(v, (true, true)).expect("Failed to build BinLookup")
+}
+
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
 fn build_score_matrix(
@@ -403,24 +409,16 @@ fn build_score_matrix(
             }
         }
 
-        if let Some(mut inner) = dist_inner_bounds {
-            inner.insert(0, NEG_INFINITY);
-            inner.push(INFINITY);
-            smatb.set_dist_lookup(
-                BinLookup::new(inner, (true, true)).expect("failed to build dist lookup"),
-            );
+        if let Some(inner) = dist_inner_bounds {
+            smatb.set_dist_lookup(inner_bounds_to_binlookup(inner));
         } else if let Some(n) = dist_n_bins {
             smatb.set_n_dist_bins(n);
         } else {
             unimplemented!("should supply dist_inner_bounds or dist_n_bins");
         }
 
-        if let Some(mut inner) = dot_inner_bounds {
-            inner.insert(0, NEG_INFINITY);
-            inner.push(INFINITY);
-            smatb.set_dot_lookup(
-                BinLookup::new(inner, (true, true)).expect("failed to build dot lookup"),
-            );
+        if let Some(inner) = dot_inner_bounds {
+            smatb.set_dot_lookup(inner_bounds_to_binlookup(inner));
         } else if let Some(n) = dot_n_bins {
             smatb.set_n_dot_bins(n);
         } else {

--- a/nblast-py/src/lib.rs
+++ b/nblast-py/src/lib.rs
@@ -33,14 +33,12 @@ fn str_to_sym(s: &str) -> Result<Symmetry, ()> {
     }
 }
 
-#[cfg(not(test))]
 #[pyclass]
 pub struct ArenaWrapper {
     arena: NblastArena<RStarTangentsAlphas>,
     k: usize,
 }
 
-#[cfg(not(test))]
 #[pymethods]
 impl ArenaWrapper {
     #[new]
@@ -196,14 +194,12 @@ impl ArenaWrapper {
     }
 }
 
-#[cfg(not(test))]
 #[pyclass]
 struct ResamplingArbor {
     tree: Tree<(usize, [Precision; 3])>,
     tnid_to_id: HashMap<usize, NodeId>,
 }
 
-#[cfg(not(test))]
 #[pymethods]
 impl ResamplingArbor {
     #[new]
@@ -325,7 +321,6 @@ fn get_version(_py: Python) -> String {
     env!("CARGO_PKG_VERSION").to_string()
 }
 
-#[cfg(not(test))]
 #[pymodule]
 fn pynblast(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<ArenaWrapper>()?;

--- a/nblast-py/src/lib.rs
+++ b/nblast-py/src/lib.rs
@@ -1,16 +1,16 @@
 use core::fmt::Debug;
-use std::f64::{NEG_INFINITY, INFINITY};
 use pyo3::exceptions;
 use pyo3::prelude::*;
 use std::collections::HashMap;
+use std::f64::{INFINITY, NEG_INFINITY};
 
 use neurarbor::slab_tree::{NodeId, Tree};
 use neurarbor::{edges_to_tree_with_data, resample_tree_points, Location, SpatialArbor, TopoArbor};
 
 use nblast::nalgebra::base::{Unit, Vector3};
 use nblast::{
-    NblastArena, NeuronIdx, Precision, RStarTangentsAlphas, RangeTable, ScoreCalc, Symmetry,
-    TangentAlpha, ScoreMatrixBuilder, BinLookup
+    BinLookup, NblastArena, NeuronIdx, Precision, RStarTangentsAlphas, RangeTable, ScoreCalc,
+    ScoreMatrixBuilder, Symmetry, TangentAlpha,
 };
 
 use nblast::rayon;
@@ -315,27 +315,33 @@ impl ResamplingArbor {
     }
 }
 
-fn make_neurons_many(points_list: Vec<Vec<Vec<Precision>>>, k: usize, threads: Option<usize>) -> Vec<RStarTangentsAlphas> {
+fn make_neurons_many(
+    points_list: Vec<Vec<Vec<Precision>>>,
+    k: usize,
+    threads: Option<usize>,
+) -> Vec<RStarTangentsAlphas> {
     if let Some(t) = threads {
         let pool = rayon::ThreadPoolBuilder::new()
             .num_threads(t)
             .build()
             .unwrap();
         pool.install(|| {
-            points_list.into_par_iter().map(|ps| {
-                RStarTangentsAlphas::new(
-                    ps.into_iter().map(|p| vec_to_array3(&p)),
-                    k
-                ).expect("failed to construct neuron")  // todo: error handling
-            }).collect()
+            points_list
+                .into_par_iter()
+                .map(|ps| {
+                    RStarTangentsAlphas::new(ps.into_iter().map(|p| vec_to_array3(&p)), k)
+                        .expect("failed to construct neuron") // todo: error handling
+                })
+                .collect()
         })
     } else {
-        points_list.into_iter().map(|ps| {
-            RStarTangentsAlphas::new(
-                ps.into_iter().map(|p| vec_to_array3(&p)),
-                k
-            ).expect("failed to construct neuron")  // todo: error handling
-        }).collect()
+        points_list
+            .into_iter()
+            .map(|ps| {
+                RStarTangentsAlphas::new(ps.into_iter().map(|p| vec_to_array3(&p)), k)
+                    .expect("failed to construct neuron") // todo: error handling
+            })
+            .collect()
     }
 }
 
@@ -354,15 +360,12 @@ fn build_score_matrix(
     dot_n_bins: Option<usize>,
     dot_inner_bounds: Option<Vec<Precision>>,
     max_matching_pairs: Option<usize>,
-    max_nonmatching_pairs: Option<usize>
+    max_nonmatching_pairs: Option<usize>,
 ) -> (Vec<Precision>, Vec<Precision>, Vec<Precision>) {
-    py.allow_threads(||{
+    py.allow_threads(|| {
         let neurons = make_neurons_many(points, k, threads);
-        let mut smatb = ScoreMatrixBuilder::new(
-            neurons, seed
-        );
-        smatb.set_threads(threads)
-            .set_use_alpha(use_alpha);
+        let mut smatb = ScoreMatrixBuilder::new(neurons, seed);
+        smatb.set_threads(threads).set_use_alpha(use_alpha);
 
         if let Some(mmp) = max_matching_pairs {
             smatb.set_max_matching_pairs(mmp);
@@ -384,7 +387,9 @@ fn build_score_matrix(
         if let Some(mut inner) = dist_inner_bounds {
             inner.insert(0, NEG_INFINITY);
             inner.push(INFINITY);
-            smatb.set_dist_lookup(BinLookup::new(inner, (true, true)).expect("failed to build dist lookup"));
+            smatb.set_dist_lookup(
+                BinLookup::new(inner, (true, true)).expect("failed to build dist lookup"),
+            );
         } else if let Some(n) = dist_n_bins {
             smatb.set_n_dist_bins(n);
         } else {
@@ -394,7 +399,9 @@ fn build_score_matrix(
         if let Some(mut inner) = dot_inner_bounds {
             inner.insert(0, NEG_INFINITY);
             inner.push(INFINITY);
-            smatb.set_dot_lookup(BinLookup::new(inner, (true, true)).expect("failed to build dot lookup"));
+            smatb.set_dot_lookup(
+                BinLookup::new(inner, (true, true)).expect("failed to build dot lookup"),
+            );
         } else if let Some(n) = dot_n_bins {
             smatb.set_n_dot_bins(n);
         } else {
@@ -404,11 +411,7 @@ fn build_score_matrix(
         let mut table = smatb.build().expect("Failed to build score matrix");
         let dot_bounds = table.bins_lookup.lookups.pop().unwrap().bin_boundaries;
         let dist_bounds = table.bins_lookup.lookups.pop().unwrap().bin_boundaries;
-        (
-            dist_bounds,
-            dot_bounds,
-            table.cells,
-        )
+        (dist_bounds, dot_bounds, table.cells)
     })
 }
 

--- a/nblast-py/src/lib.rs
+++ b/nblast-py/src/lib.rs
@@ -57,10 +57,7 @@ impl ArenaWrapper {
         if let Some(t) = threads {
             arena = arena.with_threads(t);
         }
-        Ok(Self {
-            arena,
-            k,
-        })
+        Ok(Self { arena, k })
     }
 
     pub fn add_points(&mut self, py: Python, points: Vec<Vec<f64>>) -> PyResult<usize> {
@@ -156,9 +153,7 @@ impl ArenaWrapper {
             })?),
             _ => None,
         };
-        Ok(self
-            .arena
-            .all_v_all(normalize, &sym, max_centroid_dist))
+        Ok(self.arena.all_v_all(normalize, &sym, max_centroid_dist))
     }
 
     pub fn len(&self) -> usize {

--- a/nblast-py/src/lib.rs
+++ b/nblast-py/src/lib.rs
@@ -352,7 +352,6 @@ fn build_score_matrix(
     k: usize,
     seed: u64,
     use_alpha: bool,
-    threads: Option<usize>,
     matching_sets: Vec<Vec<usize>>,
     nonmatching_sets: Option<Vec<Vec<usize>>>,
     dist_n_bins: Option<usize>,
@@ -361,6 +360,7 @@ fn build_score_matrix(
     dot_inner_bounds: Option<Vec<Precision>>,
     max_matching_pairs: Option<usize>,
     max_nonmatching_pairs: Option<usize>,
+    threads: Option<usize>,
 ) -> (Vec<Precision>, Vec<Precision>, Vec<Precision>) {
     py.allow_threads(|| {
         let neurons = make_neurons_many(points, k, threads);

--- a/nblast-py/tests/conftest.py
+++ b/nblast-py/tests/conftest.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List, Dict, Optional
+from typing import Callable, Tuple, List, Dict, Optional
 from pathlib import Path
 import json
 
@@ -35,6 +35,24 @@ def points() -> List[Tuple[str, pd.DataFrame]]:
 @pytest.fixture
 def arena(score_mat_tup):
     return pynblast.NblastArena(*score_mat_tup, k=5)
+
+
+@pytest.fixture
+def arena_names_factory(
+    score_mat_tup, points
+) -> Callable[[bool, Optional[int]], Tuple[pynblast.NblastArena, dict[int, str]]]:
+    def fn(use_alpha, threads):
+        arena = pynblast.NblastArena(
+            *score_mat_tup, k=5, use_alpha=use_alpha, threads=threads
+        )
+
+        idx_to_name = dict()
+        for name, df in points:
+            idx = arena.add_points(df.to_numpy())
+            idx_to_name[idx] = name
+        return arena, idx_to_name
+
+    return fn
 
 
 @pytest.fixture

--- a/nblast-py/tests/test_integration.py
+++ b/nblast-py/tests/test_integration.py
@@ -23,9 +23,9 @@ def dict_to_df(idxs_to_score, idx_to_name):
 
 
 @pytest.mark.parametrize(["threads"], [(None,), (0,), (1,)])
-def test_vs_r(arena_names, expected_nblast, threads):
-    arena, idx_to_name = arena_names
-    idxs_to_score = arena.all_v_all(threads=threads)
+def test_vs_r(arena_names_factory, expected_nblast, threads):
+    arena, idx_to_name = arena_names_factory(False, threads)
+    idxs_to_score = arena.all_v_all()
 
     for (q_idx, t_idx), score in idxs_to_score.items():
         q_name = idx_to_name[q_idx]

--- a/nblast-py/tests/test_nblast.py
+++ b/nblast-py/tests/test_nblast.py
@@ -13,6 +13,9 @@ from pynblast import NblastArena, Idx, ScoreMatrix, rectify_tangents, Symmetry
 EPSILON = 0.001
 
 
+ArenaNames = tuple[NblastArena, dict[Idx, str]]
+
+
 def test_read_smat(smat_path):
     dist_bins, dot_bins, arr = ScoreMatrix.read(smat_path)
     assert arr.shape == (len(dist_bins) - 1, len(dot_bins) - 1)
@@ -27,6 +30,12 @@ def test_construction(score_mat_tup):
 def test_insertion(arena: NblastArena, points):
     df = points[0][1]
     arena.add_points(df.to_numpy())
+
+
+def sort3(p: np.ndarray) -> np.ndarray:
+    lst = p.tolist()
+    lst.sort()
+    return np.asarray(lst)
 
 
 def test_points_conserved(arena: NblastArena, points):
@@ -55,7 +64,7 @@ def test_rectify_tangents(test, expected):
     assert np.allclose(out, expected)
 
 
-def test_tangents(arena, dotprops):
+def test_tangents(arena: NblastArena, dotprops):
     df = dotprops[0][1]
     points = df[["points." + d for d in "XYZ"]].to_numpy()
     expected_tangents = rectify_tangents(
@@ -82,13 +91,26 @@ def test_query(arena_names: Tuple[NblastArena, Dict[int, str]]):
     assert result
 
 
-def all_v_all(arena, names, normalize=False, symmetry=None):
-    q = list(names)
-    return arena.queries_targets(q, q, normalize, symmetry=symmetry)
+def all_v_all(arena: NblastArena, names, normalize=False, symmetry=None):
+    return arena.all_v_all(normalize, symmetry)
+    # q = list(names)
+
+    # return arena.queries_targets(q, q, normalize, symmetry=symmetry)
 
 
 def test_all_v_all(arena_names: Tuple[NblastArena, Dict[int, str]]):
     out = all_v_all(*arena_names)
+    assert len(out) == len(arena_names[1]) ** 2
+
+
+def test_qs_ts_sym(arena_names: ArenaNames):
+    arena, names = arena_names
+    out = arena.queries_targets(list(names), list(names), symmetry="arithmetic_mean")
+    assert len(out) == len(names) ** 2
+
+
+def test_all_v_all_sym(arena_names: Tuple[NblastArena, Dict[int, str]]):
+    out = all_v_all(*arena_names, symmetry="arithmetic_mean")
     assert len(out) == len(arena_names[1]) ** 2
 
 

--- a/nblast-py/tests/test_nblast.py
+++ b/nblast-py/tests/test_nblast.py
@@ -82,22 +82,25 @@ def test_query(arena_names: Tuple[NblastArena, Dict[int, str]]):
     assert result
 
 
-def all_v_all(arena, names, normalize=False, symmetry=None, threads=None):
+def all_v_all(arena, names, normalize=False, symmetry=None):
     q = list(names)
-    return arena.queries_targets(q, q, normalize, symmetry=symmetry, threads=threads)
+    return arena.queries_targets(q, q, normalize, symmetry=symmetry)
 
 
 def test_all_v_all(arena_names: Tuple[NblastArena, Dict[int, str]]):
-    out = all_v_all(*arena_names, threads=None)
+    out = all_v_all(*arena_names)
     assert len(out) == len(arena_names[1]) ** 2
 
 
-def test_all_v_all_par(arena_names: Tuple[NblastArena, Dict[int, str]]):
-    t_none = all_v_all(*arena_names, threads=None)
-    t_1 = all_v_all(*arena_names, threads=1)
-    t_0 = all_v_all(*arena_names, threads=0)
-    assert t_none == t_1
-    assert t_1 == t_0
+def test_all_v_all_par(arena_names_factory):
+    out = []
+
+    for threads in [None, 1, 2]:
+        arena, names = arena_names_factory(False, threads)
+        out.append(all_v_all(arena, names))
+
+    assert out[0] == out[1]
+    assert out[0] == out[2]
 
 
 def test_normed(arena_names):

--- a/nblast-rs/Cargo.toml
+++ b/nblast-rs/Cargo.toml
@@ -20,8 +20,6 @@ categories = ["algorithms", "science"]
 
 nalgebra = "0.31"
 rstar = "0.9"
-# rand = { version = "0.8", default-features = false }
-# rand_pcg = "0.3"
 fastrand = "1.9"
 rayon = { version = "1.5", optional = true }
 thiserror = "1.0"

--- a/nblast-rs/benches/bench.rs
+++ b/nblast-rs/benches/bench.rs
@@ -1,7 +1,6 @@
-use std::collections::HashSet;
 use std::iter::repeat_with;
 use std::path::PathBuf;
-use std::{f64::consts::PI, fs::File};
+use std::fs::File;
 
 use bencher::{benchmark_group, benchmark_main, Bencher};
 use csv::ReaderBuilder;

--- a/nblast-rs/benches/bench.rs
+++ b/nblast-rs/benches/bench.rs
@@ -84,7 +84,9 @@ fn read_all_points() -> Vec<Vec<Point3>> {
     NAMES.iter().map(|n| read_points(n)).collect()
 }
 
-fn match_nonmatch(repeats: usize) -> (Vec<Vec<Point3>>, Vec<Vec<usize>>, Vec<Vec<usize>>) {
+pub type MatchNonmatch = (Vec<Vec<Point3>>, Vec<Vec<usize>>, Vec<Vec<usize>>);
+
+fn match_nonmatch(repeats: usize) -> MatchNonmatch {
     let n_csvs = NAMES.len();
     let mut out_points = Vec::with_capacity(n_csvs * repeats);
     let all_points = read_all_points();
@@ -98,7 +100,7 @@ fn match_nonmatch(repeats: usize) -> (Vec<Vec<Point3>>, Vec<Vec<usize>>, Vec<Vec
 
     let rng = Rng::with_seed(1991);
 
-    for rep in 0..repeats {
+    for (rep, nm) in nonmatches.iter_mut().enumerate() {
         let aug = PointAug::new_random(
             0.5,  // 500nm
             0.02, // 20nm
@@ -110,7 +112,7 @@ fn match_nonmatch(repeats: usize) -> (Vec<Vec<Point3>>, Vec<Vec<usize>>, Vec<Vec
             let global_p_idx = offset + p_idx;
             out_points.push(aug.augment_all(ps));
             matches[p_idx].push(global_p_idx);
-            nonmatches[rep].push(global_p_idx);
+            nm.push(global_p_idx);
         }
     }
 

--- a/nblast-rs/benches/bench.rs
+++ b/nblast-rs/benches/bench.rs
@@ -1,6 +1,6 @@
+use std::fs::File;
 use std::iter::repeat_with;
 use std::path::PathBuf;
-use std::fs::File;
 
 use bencher::{benchmark_group, benchmark_main, Bencher};
 use csv::ReaderBuilder;

--- a/nblast-rs/src/lib.rs
+++ b/nblast-rs/src/lib.rs
@@ -174,8 +174,6 @@ impl Symmetry {
     }
 }
 
-
-
 /// The result of comparing two (point, tangent) tuples.
 /// Contains the Euclidean distance between the points,
 /// and the absolute dot product of the (unit) tangents,

--- a/nblast-rs/src/lib.rs
+++ b/nblast-rs/src/lib.rs
@@ -152,8 +152,10 @@ impl TangentAlpha {
 /// Geometric and harmonic means bound the output to be >= 0.0.
 /// Geometric mean may work best with non-normalized queries.
 /// Max may work if an unknown one of the query and target is incomplete.
+#[derive(Default)]
 pub enum Symmetry {
     ArithmeticMean,
+    #[default]
     GeometricMean,
     HarmonicMean,
     Min,
@@ -172,11 +174,7 @@ impl Symmetry {
     }
 }
 
-impl Default for Symmetry {
-    fn default() -> Self {
-        Symmetry::GeometricMean
-    }
-}
+
 
 /// The result of comparing two (point, tangent) tuples.
 /// Contains the Euclidean distance between the points,

--- a/nblast-rs/src/lib.rs
+++ b/nblast-rs/src/lib.rs
@@ -61,9 +61,9 @@ use nalgebra::base::{Matrix3, Unit, Vector3};
 use std::collections::{HashMap, HashSet};
 
 #[cfg(feature = "parallel")]
-use rayon::prelude::*;
-#[cfg(feature = "parallel")]
 pub use rayon;
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 
 pub use nalgebra;
 

--- a/nblast-rs/src/lib.rs
+++ b/nblast-rs/src/lib.rs
@@ -631,7 +631,7 @@ where
         }
         let mut jobs = HashSet::with_capacity(max_jobs);
         for (q, t) in query_target_idxs {
-            if q > &self.len() || t > &self.len() || jobs.contains(&(*q, *t)) {
+            if q > &self.len() || t > &self.len() {
                 continue;
             }
 
@@ -649,6 +649,10 @@ where
                 continue;
             } else {
                 out.insert(key, Precision::NAN);
+            }
+
+            if jobs.contains(&(*q, *t)) {
+                continue;
             }
 
             if let Some(d) = max_centroid_dist {

--- a/nblast-rs/src/neurons/mod.rs
+++ b/nblast-rs/src/neurons/mod.rs
@@ -1,3 +1,4 @@
+//! Neurites which can be queried against each other.
 use crate::{centroid, DistDot, Normal3, Point3, Precision, ScoreCalc};
 
 // pub mod fnntw;

--- a/nblast-rs/src/neurons/nabo.rs
+++ b/nblast-rs/src/neurons/nabo.rs
@@ -105,10 +105,7 @@ impl NaboTangentsAlphas {
         let (tree, tangents_alphas) = points_to_nabo_tangents_alphas(points.iter(), k);
         Self {
             tree,
-            points_tangents_alphas: points
-                .into_iter()
-                .zip(tangents_alphas)
-                .collect(),
+            points_tangents_alphas: points.into_iter().zip(tangents_alphas).collect(),
         }
     }
 
@@ -120,10 +117,7 @@ impl NaboTangentsAlphas {
         let tree = points_to_nabo(points.iter());
         Self {
             tree,
-            points_tangents_alphas: points
-                .into_iter()
-                .zip(tangents_alphas)
-                .collect(),
+            points_tangents_alphas: points.into_iter().zip(tangents_alphas).collect(),
         }
     }
 }

--- a/nblast-rs/src/neurons/nabo.rs
+++ b/nblast-rs/src/neurons/nabo.rs
@@ -1,3 +1,4 @@
+//! Neuron types using the [nabo](https://crates.io/crates/nabo) crate as a backend.
 use super::{Neuron, QueryNeuron, TargetNeuron};
 use crate::{
     centroid, geometric_mean, DistDot, Normal3, Point3, Precision, ScoreCalc, TangentAlpha,

--- a/nblast-rs/src/neurons/nabo.rs
+++ b/nblast-rs/src/neurons/nabo.rs
@@ -107,7 +107,7 @@ impl NaboTangentsAlphas {
             tree,
             points_tangents_alphas: points
                 .into_iter()
-                .zip(tangents_alphas.into_iter())
+                .zip(tangents_alphas)
                 .collect(),
         }
     }
@@ -122,7 +122,7 @@ impl NaboTangentsAlphas {
             tree,
             points_tangents_alphas: points
                 .into_iter()
-                .zip(tangents_alphas.into_iter())
+                .zip(tangents_alphas)
                 .collect(),
         }
     }

--- a/nblast-rs/src/neurons/rstar.rs
+++ b/nblast-rs/src/neurons/rstar.rs
@@ -1,3 +1,4 @@
+//! Neuron types using the [rstar](https://crates.io/crates/rstar) crate as a backend.
 use super::{Neuron, QueryNeuron, TargetNeuron};
 use crate::{
     centroid, geometric_mean, DistDot, Normal3, Point3, Precision, ScoreCalc, TangentAlpha,

--- a/nblast-rs/src/smat.rs
+++ b/nblast-rs/src/smat.rs
@@ -351,11 +351,13 @@ enum LookupArgs {
 /// At a minimum, one matching set must be added (`.add_matching_set`),
 /// and the dist and dot bins must either be set automatically or calculated
 /// (`.set_(n_)?(dist|dot)_bins`).
+#[allow(dead_code)]
 pub struct ScoreMatrixBuilder<T: TargetNeuron> {
     // Data set of neuron point clouds
     neurons: Vec<T>,
     sampler: TrainingSampler,
     use_alpha: bool,
+    // shows as dead code without parallel feature
     threads: Option<usize>,
     dist_bin_lookup: Option<LookupArgs>,
     dot_bin_lookup: Option<LookupArgs>,

--- a/nblast-rs/src/smat.rs
+++ b/nblast-rs/src/smat.rs
@@ -28,9 +28,11 @@ use std::collections::HashSet;
 use std::error;
 use std::fmt;
 use std::iter;
+use std::ops::Range;
 #[cfg(feature = "rayon")]
 use std::sync::mpsc::channel;
 
+use crate::Neuron;
 use crate::{BinLookup, NdBinLookup, RangeTable};
 use crate::{DistDot, Precision, TargetNeuron};
 
@@ -72,12 +74,12 @@ fn logspace(
 struct PairSampler {
     sets: Vec<Vec<usize>>,
     cumu_weights: Vec<f64>,
-    rng: fastrand::Rng,
+    pub rng: fastrand::Rng,
 }
 
 impl PairSampler {
     fn new(sets: Vec<Vec<usize>>, seed: Option<u64>) -> Self {
-        let mut rng = fastrand::Rng::new();
+        let rng = fastrand::Rng::new();
         if let Some(s) = seed {
             rng.seed(s);
         }
@@ -88,10 +90,14 @@ impl PairSampler {
             acc += *x / total;
             *x = acc;
         }
-        Self { sets, cumu_weights: weights, rng }
+        Self {
+            sets,
+            cumu_weights: weights,
+            rng,
+        }
     }
 
-    pub fn new_from_sets(sets: &[HashSet<usize>], seed: Option<u64>) -> Self {
+    pub fn from_sets(sets: &[HashSet<usize>], seed: Option<u64>) -> Self {
         let vecs = sets
             .iter()
             .map(|s| {
@@ -111,14 +117,18 @@ impl PairSampler {
             return 0;
         }
         let rand = self.rng.f64();
-        match self.cumu_weights.binary_search_by(|w| w.partial_cmp(&rand).expect("NaN weight")) {
+        match self
+            .cumu_weights
+            .binary_search_by(|w| w.partial_cmp(&rand).expect("NaN weight"))
+        {
             Ok(idx) => idx,
             Err(idx) => idx,
         }
     }
 
     pub fn sample(&mut self) -> (usize, usize) {
-        let set = self.sets[self.outer_idx()];
+        let set_idx = self.outer_idx();
+        let set = &self.sets[set_idx];
         let first = self.rng.usize(0..set.len());
         let mut second = first;
         while second == first {
@@ -127,12 +137,53 @@ impl PairSampler {
         (first, second)
     }
 
-    pub fn sample_n(&mut self, n: usize) -> Vec<(usize, usize)> {
-        std::iter::repeat_with(|| self.sample()).take(n).collect()
+    /// If not enough unique pairs can be found, the Err response contains all pairs, but fewer than requested.
+    pub fn sample_n(
+        &mut self,
+        n: usize,
+    ) -> Result<HashSet<(usize, usize)>, HashSet<(usize, usize)>> {
+        let mut out = HashSet::default();
+
+        // If n is not much less than the total number of pairs,
+        // easier to enumerate all pairs and shuffle from them.
+        if n * 10 < self.n_pairs() {
+            let mut count = 0;
+            while out.len() < n {
+                out.insert(self.sample());
+                count += 1;
+                if count >= n * 10 {
+                    return Err(out);
+                }
+            }
+        } else {
+            let mut v = self.exhaust();
+            self.rng.shuffle(&mut v);
+
+            while out.len() < n {
+                if let Some(s) = v.pop() {
+                    out.insert(s);
+                } else {
+                    return Err(out);
+                }
+            }
+        }
+        Ok(out)
     }
 
-    pub fn len(&self) -> usize {
-        self.sets.iter().map(|v| v.len().pow(2)).sum()
+    /// Upper bound on the number of pairs.
+    /// If some pair sets intersect, there could be fewer unique pairs.
+    pub fn n_pairs(&self) -> usize {
+        self.sets
+            .iter()
+            .map(|v| {
+                let len = v.len();
+                if len < 2 {
+                    0
+                } else {
+                    len * (len - 1)
+                }
+            })
+            .sum()
     }
 
     pub fn n_sets(&self) -> usize {
@@ -154,6 +205,183 @@ impl PairSampler {
 
         out
     }
+}
+
+pub struct TrainingSampler {
+    rng: fastrand::Rng,
+    matching_sets: Vec<HashSet<usize>>,
+    nonmatching_sets: Option<Vec<HashSet<usize>>>,
+    n_neurons: usize,
+}
+
+impl TrainingSampler {
+    pub fn new(n_neurons: usize, seed: Option<u64>) -> Self {
+        let rng = fastrand::Rng::new();
+        if let Some(s) = seed {
+            rng.seed(s);
+        }
+        Self {
+            rng,
+            matching_sets: Vec::default(),
+            nonmatching_sets: None,
+            n_neurons,
+        }
+    }
+
+    /// Add a set of neurons which are considered to be mutually matching,
+    /// as indices into a vec of neurons of length `self.n_neurons`.
+    /// This can be done several times with different sets.
+    /// Matching sets should be small subsets of the total neuron count.
+    ///
+    /// Indices outside of the neuron vec will be silently filtered out.
+    /// Filtered sets with length <2 will also be silently ignored.
+    pub fn add_matching_set(&mut self, matching: &[usize]) -> &mut Self {
+        // ensure all neurons exist
+        let set: HashSet<usize> = matching
+            .iter()
+            .filter_map(|idx| {
+                if idx < &self.n_neurons {
+                    Some(*idx)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if set.len() >= 2 {
+            self.matching_sets.push(set);
+        }
+        self
+    }
+
+    /// Optionally list neuron sets which are mutually non-matching,
+    /// as indices into a vec of neurons of length `self.n_neurons`,
+    /// from which non-matching pairs will be randomly drawn.
+    /// By default, all neurons are included,
+    /// as matching sets are expected to be only a small portion of the total neurons.
+    ///
+    /// Candidate non-matching pairs are made sure not to be in the matching pairs,
+    /// so this can safely be ignored.
+    pub fn add_nonmatching_set(&mut self, nonmatching: &[usize]) -> &mut Self {
+        let set: HashSet<usize> = nonmatching
+            .iter()
+            .filter_map(|idx| {
+                if idx < &self.n_neurons {
+                    Some(*idx)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if set.len() < 2 {
+            return self;
+        }
+
+        if let Some(ref mut vector) = self.nonmatching_sets {
+            vector.push(set);
+        } else {
+            let mut v = Vec::default();
+            v.push(set);
+            self.nonmatching_sets = Some(v);
+        }
+        self
+    }
+
+    /// Generate the "jobs" for matching and nonmatching neuron queries.
+    ///
+    /// If n_matching is `None`, uses all unique ordered matching pairs.
+    /// If n_nonmatching is `None`, uses the same number as there are matching pairs.
+    ///
+    /// The first element of the tuple is the matching jobs; the second set is non-matching.
+    pub fn make_jobs(
+        &self,
+        n_matching: Option<usize>,
+        n_nonmatching: Option<usize>,
+    ) -> (JobSet, JobSet) {
+        let mut match_sampler =
+            PairSampler::from_sets(&self.matching_sets, Some(self.rng.u64(0..u64::MAX)));
+
+        let matching_jobs: JobSet = match n_matching {
+            Some(n) => match match_sampler.sample_n(n) {
+                Ok(jobs) => jobs,
+                Err(jobs) => jobs,
+            },
+            None => match_sampler.exhaust().into_iter().collect(),
+        };
+
+        // if nonmatching not given, use all neurons
+        let nonmatch_seed = Some(self.rng.u64(0..u64::MAX));
+        let mut nonmatch_sampler = self.nonmatching_sets.as_ref().map_or_else(
+            || {
+                let v = vec![(0..self.n_neurons).collect()];
+                PairSampler::from_sets(&v, nonmatch_seed)
+            },
+            |s| PairSampler::from_sets(&s, nonmatch_seed),
+        );
+
+        let n_nm = n_nonmatching.unwrap_or(matching_jobs.len());
+
+        if n_nm > nonmatch_sampler.n_pairs() {
+            panic!("Not enough non-matching neurons")
+        }
+
+        let nonmatching_jobs = nonmatch_sampler.sample_n(n_nm).unwrap_or_else(|s| s);
+
+        (matching_jobs, nonmatching_jobs)
+    }
+}
+
+fn all_distdots<T: TargetNeuron>(
+    neurons: &[T],
+    jobs: &[(usize, usize)],
+    use_alpha: bool,
+) -> Vec<DistDot> {
+    jobs.iter()
+        .map(|(q, t)| neurons[*q].query_dist_dots(&neurons[*t], use_alpha))
+        .flatten()
+        .collect()
+}
+
+/// Uses global thread pool by default. To use your own threadpool, use
+///
+/// ```rust
+/// let pool = rayon::ThreadPoolBuilder::new()
+///     .num_threads(n_threads)
+///     .build()
+///     .unwrap();
+/// let results = pool.install(|| all_distdots_par(&neurons, &jobs, use_alpha));
+/// ```
+#[cfg(feature = "parallel")]
+pub fn all_distdots_par<T: TargetNeuron + Sync>(
+    neurons: &[T],
+    jobs: &[(usize, usize)],
+    use_alpha: bool,
+) -> Vec<DistDot> {
+    jobs.par_iter()
+        .map(|(q, t)| neurons[*q].query_dist_dots(&neurons[*t], use_alpha))
+        .flatten()
+        .collect()
+}
+
+/// Find indices into a flattened array of `DistDot`s (as returned by `all_distdots` et al.)
+/// which correspond to particular jobs.
+/// i.e. element `i` of the output will contain a range which corresponds to the job at `jobs[i]`.
+/// If the same neurons and jobs were given to `all_distdots`, that range could index the output
+/// to find the distdots corresponding to that job.
+pub fn job_idxs<T: Neuron>(neurons: &[T], jobs: &[(usize, usize)]) -> Vec<Range<usize>> {
+    let mut start = 0;
+    let mut out = Vec::with_capacity(jobs.len());
+    for (q, _) in jobs.iter() {
+        let len = neurons[*q].len();
+        out.push(start..start + len);
+        start += len;
+    }
+    out
+}
+
+enum LookupArgs {
+    Lookup(BinLookup<Precision>),
+    NBins(usize),
 }
 
 /// Calculate a score matrix (lookup table for converting point matches
@@ -327,65 +555,28 @@ impl<T: TargetNeuron + Sync> ScoreMatrixBuilder<T> {
     /// (if `None`, use all neurons) until there are at least as many non-matching DistDots
     /// as there are matching.
     fn _match_nonmatch_jobs(&self) -> (JobSet, JobSet) {
-        let mut matching_len = 0;
-        let mut matching_jobs = JobSet::default();
+        let rng = fastrand::Rng::with_seed(self.seed);
 
-        // for every matching set
-        for matching_set in self.matching_sets.iter() {
-            // for every possible query idx
-            for q_idx in matching_set.iter() {
-                // if the idx is in the given neurons
-                let q_len = match self.neurons.get(*q_idx) {
-                    Some(n) => n.len(),
-                    None => continue,
-                };
-                // for every possible target idx
-                for t_idx in matching_set.iter() {
-                    // if t!=q, t exists, and the pair is not already addressed
-                    if t_idx != q_idx
-                        && t_idx < &self.neurons.len()
-                        && matching_jobs.insert((*q_idx, *t_idx))
-                    {
-                        // keep track of how many distdots we're producing
-                        matching_len += q_len
-                    }
-                }
-            }
-        }
+        let match_sampler = PairSampler::from_sets(&self.matching_sets, Some(rng.u64(0..u64::MAX)));
+        let matching_jobs: JobSet = match_sampler.exhaust().into_iter().collect();
 
         // if nonmatching not given, use all neurons
-        let nonmatching_sets = self
-            .nonmatching_sets
-            .unwrap_or_else(|| vec![(0..self.neurons.len()).collect()]);
+        let nonmatch_seed = Some(rng.u64(0..u64::MAX));
+        let mut nonmatch_sampler = self.nonmatching_sets.as_ref().map_or_else(
+            || {
+                let v = vec![(0..self.neurons.len()).collect()];
+                PairSampler::from_sets(&v, nonmatch_seed)
+            },
+            |s| PairSampler::from_sets(&s, nonmatch_seed),
+        );
 
-        let nonmatching_idxs = self
-            .nonmatching_sets
-            .as_ref()
-            .cloned() // ? is this avoidable
-            .or_else(|| Some(vec![(0..self.neurons.len()).collect()]))
-            .unwrap();
-
-        if matching_jobs.len() > nonmatching_idxs.len() * (nonmatching_idxs.len() - 1) {
+        if matching_jobs.len() > nonmatch_sampler.n_pairs() {
             panic!("Not enough non-matching neurons")
         }
 
-        let idx_range = ..nonmatching_idxs.len();
-        let rng = fastrand::Rng::new();
-        rng.seed(self.seed);
-
-        let mut nonmatching_jobs: HashSet<(usize, usize)> = HashSet::default();
-
-        // randomly pick nonmatching pairs until we have requested as many distdots
-        // as we did for matching
-        while matching_len > 0 {
-            let q_idx = nonmatching_idxs[rng.usize(idx_range)];
-            let t_idx = nonmatching_idxs[rng.usize(idx_range)];
-
-            let key = (q_idx, t_idx);
-            if q_idx != t_idx && !matching_jobs.contains(&key) && nonmatching_jobs.insert(key) {
-                matching_len -= self.neurons[q_idx].len()
-            }
-        }
+        let nonmatching_jobs = nonmatch_sampler
+            .sample_n(matching_jobs.len())
+            .unwrap_or_else(|s| s);
 
         (matching_jobs, nonmatching_jobs)
     }

--- a/nblast-rs/src/smat.rs
+++ b/nblast-rs/src/smat.rs
@@ -320,7 +320,7 @@ fn all_distdots<T: TargetNeuron>(
 
 /// Uses global thread pool by default. To use your own threadpool, use
 ///
-/// ```rust
+/// ```ignore
 /// let pool = rayon::ThreadPoolBuilder::new()
 ///     .num_threads(n_threads)
 ///     .build()

--- a/nblast-rs/src/smat.rs
+++ b/nblast-rs/src/smat.rs
@@ -594,21 +594,3 @@ fn log_odds_ratio(match_counts: Vec<Precision>, nonmatch_counts: Vec<Precision>)
         })
         .collect()
 }
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    fn assert_slice_eq(test: &[Precision], reference: &[Precision]) {
-        let msg = format!("\ttest: {:?}\n\t ref: {:?}", test, reference);
-        if test.len() != reference.len() {
-            panic!("Slices have different length\n{}", msg);
-        }
-
-        for (test_val, ref_val) in test.iter().zip(reference.iter()) {
-            if (test_val - ref_val).abs() > Precision::EPSILON {
-                panic!("Slices mave mismatched values\n{}", msg)
-            }
-        }
-    }
-}

--- a/nblast-rs/src/smat.rs
+++ b/nblast-rs/src/smat.rs
@@ -584,7 +584,7 @@ fn log_odds_ratio(match_counts: Vec<Precision>, nonmatch_counts: Vec<Precision>)
 
     match_counts
         .into_iter()
-        .zip(nonmatch_counts.into_iter())
+        .zip(nonmatch_counts)
         .map(|(match_count, nonmatch_count)| {
             let p_match = match_count / match_total;
             let p_nonmatch = nonmatch_count / nonmatch_total;

--- a/nblast-rs/src/table_lookup.rs
+++ b/nblast-rs/src/table_lookup.rs
@@ -176,7 +176,7 @@ impl BinLookup<Precision> {
     /// Create a BinLookup whose boundaries are logarithmically spaced
     /// between `base^min_exp` (which should be small) and `base^max_exp`.
     /// `snap` is as in `BinLookup::new`.
-    pub fn new_log(
+    pub fn new_exp(
         base: Precision,
         min_exp: Precision,
         max_exp: Precision,
@@ -218,6 +218,17 @@ impl BinLookup<Precision> {
             })
             .collect();
         Self::new(bounds, snap)
+    }
+
+    pub fn new_n_quantiles(
+        data: &mut [Precision],
+        n_bins: usize,
+        snap: (bool, bool),
+    ) -> Result<BinLookup<Precision>, IllegalBinBoundaries> {
+        let n_bounds = n_bins + 1;
+        let step = 1.0 / n_bounds as f64;
+        let mut quantiles: Vec<_> = (0..n_bounds).map(|n| step * n as Precision).collect();
+        Self::new_quantiles(data, &mut quantiles, snap)
     }
 }
 


### PR DESCRIPTION
This is useful for e.g. lineage comparisons, where you don't want inter-lineage non-matches (which are very obvious) to obscure the intra-linear non-matches (which are the most useful bits of training data).