### PR TITLE
Spatial bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,10 @@ members = [
   "nblast-py",
   "nblast-rs",
   "nblast-js",
+  "spatial_bench",
 ]
+
+resolver = "2"
 
 # [profile.release]
 # debug = true

--- a/nblast-js/Cargo.toml
+++ b/nblast-js/Cargo.toml
@@ -13,7 +13,7 @@ serde = {version = "1", features = ["derive"]}
 serde-wasm-bindgen = "0.5"
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-nblast = { path = "../nblast-rs", version = "^0.5.0"}
+nblast = { path = "../nblast-rs", version = "^0.5.0", default-features = false, features = ["rstar"]}
 
 [lib]
 crate-type = ["cdylib"]

--- a/nblast-js/src/lib.rs
+++ b/nblast-js/src/lib.rs
@@ -86,7 +86,7 @@ impl NblastArena {
     #[wasm_bindgen(js_name = "addPoints")]
     pub fn add_points(&mut self, flat_points: &[f64]) -> JsResult<usize> {
         let points = flat_to_array3(flat_points);
-        let neuron = Neuron::new(points, self.k);
+        let neuron = Neuron::new(points, self.k).map_err(JsError::new)?;
         Ok(self.arena.add_neuron(neuron))
     }
 
@@ -106,7 +106,8 @@ impl NblastArena {
             })
             .collect();
         let points = flat_to_array3(flat_points);
-        let neuron = Neuron::new_with_tangents_alphas(points, tangents_alphas);
+        let neuron =
+            Neuron::new_with_tangents_alphas(points, tangents_alphas).map_err(JsError::new)?;
         Ok(self.arena.add_neuron(neuron))
     }
 
@@ -165,7 +166,7 @@ impl NblastArena {
 #[wasm_bindgen(js_name = "makeFlatTangentsAlphas")]
 pub fn make_flat_tangents_alphas(flat_points: &[f64], k: usize) -> JsResult<Float64Array> {
     let points = flat_to_array3(flat_points);
-    let neuron = Neuron::new(points, k);
+    let neuron = Neuron::new(points, k).map_err(JsError::new)?;
     let out = Float64Array::new_with_length(neuron.len() as u32);
     for (idx, val) in neuron
         .tangents()

--- a/nblast-js/src/lib.rs
+++ b/nblast-js/src/lib.rs
@@ -86,7 +86,7 @@ impl NblastArena {
     #[wasm_bindgen(js_name = "addPoints")]
     pub fn add_points(&mut self, flat_points: &[f64]) -> JsResult<usize> {
         let points = flat_to_array3(flat_points);
-        let neuron = Neuron::new(points, self.k).map_err(JsError::new)?;
+        let neuron = Neuron::new(points, self.k);
         Ok(self.arena.add_neuron(neuron))
     }
 
@@ -106,8 +106,7 @@ impl NblastArena {
             })
             .collect();
         let points = flat_to_array3(flat_points);
-        let neuron =
-            Neuron::new_with_tangents_alphas(points, tangents_alphas).map_err(JsError::new)?;
+        let neuron = Neuron::new_with_tangents_alphas(points, tangents_alphas);
         Ok(self.arena.add_neuron(neuron))
     }
 
@@ -166,7 +165,7 @@ impl NblastArena {
 #[wasm_bindgen(js_name = "makeFlatTangentsAlphas")]
 pub fn make_flat_tangents_alphas(flat_points: &[f64], k: usize) -> JsResult<Float64Array> {
     let points = flat_to_array3(flat_points);
-    let neuron = Neuron::new(points, k).map_err(JsError::new)?;
+    let neuron = Neuron::new(points, k);
     let out = Float64Array::new_with_length(neuron.len() as u32);
     for (idx, val) in neuron
         .tangents()

--- a/nblast-py/Cargo.toml
+++ b/nblast-py/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 pyo3 = { version = "0.18.2", features = ["extension-module"] }
 neurarbor = "0.2.0"
-nblast = { path = "../nblast-rs", version = "^0.5.0", features = ["parallel"] }
+nblast = { path = "../nblast-rs", version = "^0.5.0", features = ["parallel", "kiddo"] }
 numpy = "0.18"
 
 [lib]

--- a/nblast-py/src/lib.rs
+++ b/nblast-py/src/lib.rs
@@ -70,7 +70,8 @@ impl ArenaWrapper {
                 .map(|r| [r[0], r[1], r[2]])
                 .collect(),
             self.k,
-        );
+        )
+        .map_err(|e| PyErr::new::<PyValueError, _>(e))?;
         Ok(self.arena.add_neuron(neuron))
     }
 
@@ -112,7 +113,8 @@ impl ArenaWrapper {
                 .map(|r| [r[0], r[1], r[2]])
                 .collect(),
             tangents_alphas,
-        );
+        )
+        .map_err(|e| PyErr::new::<PyValueError, _>(e))?;
         Ok(self.arena.add_neuron(neuron))
     }
 
@@ -355,13 +357,19 @@ fn make_neurons_many(
         pool.install(|| {
             points_list
                 .into_par_iter()
-                .map(|ps| Neuron::new(ps.into_iter().map(|p| [p[0], p[1], p[2]]).collect(), k))
+                .map(|ps| {
+                    Neuron::new(ps.into_iter().map(|p| [p[0], p[1], p[2]]).collect(), k)
+                        .expect("Invalid neuron")
+                })
                 .collect()
         })
     } else {
         points_list
             .into_iter()
-            .map(|ps| Neuron::new(ps.into_iter().map(|p| [p[0], p[1], p[2]]).collect(), k))
+            .map(|ps| {
+                Neuron::new(ps.into_iter().map(|p| [p[0], p[1], p[2]]).collect(), k)
+                    .expect("invalid neuron")
+            })
             .collect()
     }
 }

--- a/nblast-py/src/lib.rs
+++ b/nblast-py/src/lib.rs
@@ -12,8 +12,8 @@ use numpy::{IntoPyArray, PyArray1, PyArray2, PyReadonlyArray1, PyReadonlyArray2}
 
 use nblast::nalgebra::base::{Unit, Vector3};
 use nblast::{
-    BinLookup, NblastArena, Neuron, NeuronIdx, Precision, RangeTable, ScoreCalc,
-    ScoreMatrixBuilder, Symmetry, TangentAlpha,
+    neurons::kiddo::ExactKiddoTangentsAlphas as Neuron, BinLookup, NblastArena, NeuronIdx,
+    Precision, RangeTable, ScoreCalc, ScoreMatrixBuilder, Symmetry, TangentAlpha,
 };
 
 use nblast::rayon;
@@ -67,10 +67,10 @@ impl ArenaWrapper {
                 .as_array()
                 .rows()
                 .into_iter()
-                .map(|r| [r[0], r[1], r[2]]),
+                .map(|r| [r[0], r[1], r[2]])
+                .collect(),
             self.k,
-        )
-        .map_err(PyErr::new::<exceptions::PyRuntimeError, _>)?;
+        );
         Ok(self.arena.add_neuron(neuron))
     }
 
@@ -109,10 +109,10 @@ impl ArenaWrapper {
                 .as_array()
                 .rows()
                 .into_iter()
-                .map(|r| [r[0], r[1], r[2]]),
+                .map(|r| [r[0], r[1], r[2]])
+                .collect(),
             tangents_alphas,
-        )
-        .map_err(PyErr::new::<exceptions::PyRuntimeError, _>)?;
+        );
         Ok(self.arena.add_neuron(neuron))
     }
 
@@ -355,19 +355,13 @@ fn make_neurons_many(
         pool.install(|| {
             points_list
                 .into_par_iter()
-                .map(|ps| {
-                    Neuron::new(ps.into_iter().map(|p| [p[0], p[1], p[2]]), k)
-                        .expect("failed to construct neuron") // todo: error handling
-                })
+                .map(|ps| Neuron::new(ps.into_iter().map(|p| [p[0], p[1], p[2]]).collect(), k))
                 .collect()
         })
     } else {
         points_list
             .into_iter()
-            .map(|ps| {
-                Neuron::new(ps.into_iter().map(|p| [p[0], p[1], p[2]]), k)
-                    .expect("failed to construct neuron") // todo: error handling
-            })
+            .map(|ps| Neuron::new(ps.into_iter().map(|p| [p[0], p[1], p[2]]).collect(), k))
             .collect()
     }
 }

--- a/nblast-rs/Cargo.toml
+++ b/nblast-rs/Cargo.toml
@@ -19,12 +19,13 @@ categories = ["algorithms", "science"]
 [dependencies]
 
 nalgebra = "0.31"
-rstar = "0.9"
+rstar = {version = "0.9", optional = true}
 fastrand = "1.9"
 rayon = { version = "1.5", optional = true }
 thiserror = "1.0"
 nabo = { version = "0.2.1", optional = true }
 kiddo = { version = "4.0", optional = true }
+cfg-if = "1.0.0"
 
 [dev-dependencies]
 
@@ -33,6 +34,7 @@ csv = "1.1"
 serde = { version = "1", features = ["derive"] }
 
 [features]
+default = ["kiddo"]
 
 parallel = ["rayon"]
 

--- a/nblast-rs/Cargo.toml
+++ b/nblast-rs/Cargo.toml
@@ -24,7 +24,7 @@ fastrand = "1.9"
 rayon = { version = "1.5", optional = true }
 thiserror = "1.0"
 nabo = { version = "0.2.1", optional = true }
-# fnntw = "0.2"
+kiddo = { version = "4.0", optional = true }
 
 [dev-dependencies]
 

--- a/nblast-rs/benches/bench.rs
+++ b/nblast-rs/benches/bench.rs
@@ -286,16 +286,16 @@ fn bench_query_nabo(b: &mut Bencher) {
 
 fn bench_query_kiddo(b: &mut Bencher) {
     let score_fn = get_score_fn();
-    let query = KiddoTangentsAlphas::new(read_points(NAMES[0]), N_NEIGHBORS);
-    let target = KiddoTangentsAlphas::new(read_points(NAMES[1]), N_NEIGHBORS);
+    let query = KiddoTangentsAlphas::new(read_points(NAMES[0]), N_NEIGHBORS).unwrap();
+    let target = KiddoTangentsAlphas::new(read_points(NAMES[1]), N_NEIGHBORS).unwrap();
 
     b.iter(|| query.query(&target, false, &score_fn))
 }
 
 fn bench_query_exact_kiddo(b: &mut Bencher) {
     let score_fn = get_score_fn();
-    let query = ExactKiddoTangentsAlphas::new(read_points(NAMES[0]), N_NEIGHBORS);
-    let target = ExactKiddoTangentsAlphas::new(read_points(NAMES[1]), N_NEIGHBORS);
+    let query = ExactKiddoTangentsAlphas::new(read_points(NAMES[0]), N_NEIGHBORS).unwrap();
+    let target = ExactKiddoTangentsAlphas::new(read_points(NAMES[1]), N_NEIGHBORS).unwrap();
 
     b.iter(|| query.query(&target, false, &score_fn))
 }
@@ -408,7 +408,7 @@ fn bench_all_to_all_serial_kiddo(b: &mut Bencher) {
     let mut idxs = Vec::new();
     for name in NAMES.iter() {
         let points = read_points(name);
-        idxs.push(arena.add_neuron(KiddoTangentsAlphas::new(points, N_NEIGHBORS)));
+        idxs.push(arena.add_neuron(KiddoTangentsAlphas::new(points, N_NEIGHBORS).unwrap()));
     }
 
     b.iter(|| arena.queries_targets(&idxs, &idxs, false, &None, None));
@@ -419,7 +419,7 @@ fn bench_all_to_all_serial_exact_kiddo(b: &mut Bencher) {
     let mut idxs = Vec::new();
     for name in NAMES.iter() {
         let points = read_points(name);
-        idxs.push(arena.add_neuron(ExactKiddoTangentsAlphas::new(points, N_NEIGHBORS)));
+        idxs.push(arena.add_neuron(ExactKiddoTangentsAlphas::new(points, N_NEIGHBORS).unwrap()));
     }
 
     b.iter(|| arena.queries_targets(&idxs, &idxs, false, &None, None));

--- a/nblast-rs/src/lib.rs
+++ b/nblast-rs/src/lib.rs
@@ -96,10 +96,10 @@
 //! // Add some neurons built from points and a neighborhood size,
 //! // returning their indices in the arena
 //! let idx1 = arena.add_neuron(
-//!     Neuron::new(random_points(6, &mut rng), 5))
+//!     Neuron::new(random_points(6, &mut rng), 5).expect("cannot construct neuron")
 //! );
 //! let idx2 = arena.add_neuron(
-//!     Neuron::new(random_points(8, &mut rng), 5))
+//!     Neuron::new(random_points(8, &mut rng), 5).expect("cannot construct neuron")
 //! );
 //!
 //! // get a raw score (not normalized by self-hit, no symmetry)
@@ -966,7 +966,7 @@ mod test {
     #[test]
     fn test_neuron() {
         let (points, exp_tan, _exp_alpha) = tangent_data();
-        let tgt = Neuron::new(points, N_NEIGHBORS);
+        let tgt = Neuron::new(points, N_NEIGHBORS).unwrap();
         assert!(equivalent_tangents(&tgt.tangents()[0], &exp_tan));
         // tested from the python side
         // assert_close(tgt.alphas()[0], exp_alpha);
@@ -1089,8 +1089,10 @@ mod test {
             RangeTable::new_from_bins(vec![dist_thresholds, dot_thresholds], cells).unwrap(),
         );
 
-        let query = Neuron::new(make_points(&[0., 0., 0.], &[1., 0., 0.], 10), N_NEIGHBORS);
-        let target = Neuron::new(make_points(&[0.5, 0., 0.], &[1.1, 0., 0.], 10), N_NEIGHBORS);
+        let query =
+            Neuron::new(make_points(&[0., 0., 0.], &[1., 0., 0.], 10), N_NEIGHBORS).unwrap();
+        let target =
+            Neuron::new(make_points(&[0.5, 0., 0.], &[1.1, 0., 0.], 10), N_NEIGHBORS).unwrap();
 
         let mut arena = NblastArena::new(score_calc, false);
         let q_idx = arena.add_neuron(query);

--- a/nblast-rs/src/lib.rs
+++ b/nblast-rs/src/lib.rs
@@ -96,10 +96,10 @@
 //! // Add some neurons built from points and a neighborhood size,
 //! // returning their indices in the arena
 //! let idx1 = arena.add_neuron(
-//!     Neuron::new(random_points(6, &mut rng), 5).expect("cannot construct neuron")
+//!     Neuron::new(random_points(6, &mut rng), 5))
 //! );
 //! let idx2 = arena.add_neuron(
-//!     Neuron::new(random_points(8, &mut rng), 5).expect("cannot construct neuron")
+//!     Neuron::new(random_points(8, &mut rng), 5))
 //! );
 //!
 //! // get a raw score (not normalized by self-hit, no symmetry)

--- a/nblast-rs/src/lib.rs
+++ b/nblast-rs/src/lib.rs
@@ -61,7 +61,7 @@
 //! ```
 //! use nblast::{NblastArena, ScoreCalc, Neuron, Symmetry};
 //!
-//! // create a lookup table for the point match scores
+//! // Create a lookup table for the point match scores
 //! let smat = ScoreCalc::table_from_bins(
 //!   vec![0.0, 0.1, 0.25, 0.5, 1.0, 5.0, f64::INFINITY], // distance thresholds
 //!   vec![0.0, 0.2, 0.4, 0.6, 0.8, 1.0], // dot product thresholds
@@ -75,7 +75,9 @@
 //!   ],
 //! ).expect("could not build score matrix");
 //!
-//! // create an arena to hold your neurons with this score function,
+//! // See the ScoreMatrixBuilder for constructing a score matrix from test data.
+//!
+//! // Create an arena to hold your neurons with this score function,
 //! // whether it should scale the dot products by the colinearity value,
 //! // and how many threads to use (default serial)
 //! let mut arena = NblastArena::new(smat, false).with_threads(2);
@@ -91,7 +93,7 @@
 //! }
 //!
 
-//! // add some neurons built from points and a neighborhood size,
+//! // Add some neurons built from points and a neighborhood size,
 //! // returning their indices in the arena
 //! let idx1 = arena.add_neuron(
 //!     Neuron::new(random_points(6, &mut rng), 5).expect("cannot construct neuron")

--- a/nblast-rs/src/neurons/kiddo.rs
+++ b/nblast-rs/src/neurons/kiddo.rs
@@ -1,0 +1,238 @@
+//! Neuron types using the [kiddo](https://crates.io/crates/kiddo) crate as a backend.
+use super::{NblastNeuron, QueryNeuron, TargetNeuron};
+use crate::{
+    centroid, geometric_mean, DistDot, Normal3, Point3, Precision, ScoreCalc, TangentAlpha,
+};
+use kiddo::{ImmutableKdTree, SquaredEuclidean};
+
+type KdTree = ImmutableKdTree<Precision, 3>;
+
+/// Target neuron using a KDTree from the kiddo crate.
+///
+/// By default, this uses approximate nearest neighbour for one-off lookups (as used in NBLAST scoring).
+/// See the [ExactKiddoTangentsAlphas] for exact 1NN.
+pub struct KiddoTangentsAlphas {
+    tree: KdTree,
+    points_tangents_alphas: Vec<(Point3, TangentAlpha)>,
+}
+
+impl KiddoTangentsAlphas {
+    /// Calculate tangents from constructed R*-tree.
+    /// `k` is the number of points to calculate each tangent with.
+    pub fn new(points: Vec<Point3>, k: usize) -> Self {
+        let tree: KdTree = points.as_slice().into();
+        let points_tangents_alphas = points
+            .iter()
+            .map(|p| {
+                let neighbors = tree.nearest_n::<SquaredEuclidean>(p, k);
+
+                let pts = neighbors.iter().map(|nn| &points[nn.item as usize]);
+                (*p, TangentAlpha::new_from_points(pts))
+            })
+            .collect();
+
+        Self {
+            tree,
+            points_tangents_alphas,
+        }
+    }
+
+    /// Use pre-calculated tangents.
+    pub fn new_with_tangents_alphas(
+        points: Vec<Point3>,
+        tangents_alphas: Vec<TangentAlpha>,
+    ) -> Self {
+        let tree: KdTree = points.as_slice().into();
+        Self {
+            tree,
+            points_tangents_alphas: points.into_iter().zip(tangents_alphas).collect(),
+        }
+    }
+
+    fn nearest_match_dist_dot_inner(
+        &self,
+        point: &Point3,
+        tangent: &Normal3,
+        alpha: Option<Precision>,
+        exact: bool,
+    ) -> DistDot {
+        let nn = if exact {
+            self.tree.nearest_one::<SquaredEuclidean>(point)
+        } else {
+            self.tree.approx_nearest_one::<SquaredEuclidean>(point)
+        };
+
+        let (_, ta) = self.points_tangents_alphas[nn.item as usize];
+
+        let raw_dot = ta.tangent.dot(tangent).abs();
+        let dot = match alpha {
+            Some(a) => raw_dot * geometric_mean(a, ta.alpha),
+            None => raw_dot,
+        };
+        DistDot {
+            dist: nn.distance.sqrt(),
+            dot,
+        }
+    }
+}
+
+impl NblastNeuron for KiddoTangentsAlphas {
+    fn len(&self) -> usize {
+        self.points_tangents_alphas.len()
+    }
+
+    fn points(&self) -> Vec<Point3> {
+        self.points_tangents_alphas
+            .iter()
+            .map(|pta| pta.0)
+            .collect()
+    }
+
+    fn centroid(&self) -> Point3 {
+        centroid(self.points().iter())
+    }
+
+    fn tangents(&self) -> Vec<Normal3> {
+        self.points_tangents_alphas
+            .iter()
+            .map(|pta| pta.1.tangent)
+            .collect()
+    }
+
+    fn alphas(&self) -> Vec<Precision> {
+        self.points_tangents_alphas
+            .iter()
+            .map(|pta| pta.1.alpha)
+            .collect()
+    }
+}
+
+impl QueryNeuron for KiddoTangentsAlphas {
+    fn query_dist_dots(&self, target: &impl TargetNeuron, use_alpha: bool) -> Vec<DistDot> {
+        self.points_tangents_alphas
+            .iter()
+            .map(|(p, tangent_alpha)| {
+                let alpha = if use_alpha {
+                    Some(tangent_alpha.alpha)
+                } else {
+                    None
+                };
+                target.nearest_match_dist_dot(p, &tangent_alpha.tangent, alpha)
+            })
+            .collect()
+    }
+
+    fn self_hit(&self, score_calc: &ScoreCalc, use_alpha: bool) -> Precision {
+        if use_alpha {
+            self.points_tangents_alphas
+                .iter()
+                .map(|(_, ta)| {
+                    score_calc.calc(&DistDot {
+                        dist: 0.0,
+                        dot: ta.alpha,
+                    })
+                })
+                .fold(0.0, |total, s| total + s)
+        } else {
+            score_calc.calc(&DistDot {
+                dist: 0.0,
+                dot: 1.0,
+            }) * self.len() as Precision
+        }
+    }
+}
+
+impl TargetNeuron for KiddoTangentsAlphas {
+    fn nearest_match_dist_dot(
+        &self,
+        point: &Point3,
+        tangent: &Normal3,
+        alpha: Option<Precision>,
+    ) -> DistDot {
+        self.nearest_match_dist_dot_inner(point, tangent, alpha, false)
+    }
+}
+
+pub struct ExactKiddoTangentsAlphas(KiddoTangentsAlphas);
+
+impl ExactKiddoTangentsAlphas {
+    /// Calculate tangents from constructed R*-tree.
+    /// `k` is the number of points to calculate each tangent with.
+    pub fn new(points: Vec<Point3>, k: usize) -> Self {
+        Self(KiddoTangentsAlphas::new(points, k))
+    }
+
+    /// Use pre-calculated tangents.
+    pub fn new_with_tangents_alphas(
+        points: Vec<Point3>,
+        tangents_alphas: Vec<TangentAlpha>,
+    ) -> Self {
+        Self(KiddoTangentsAlphas::new_with_tangents_alphas(
+            points,
+            tangents_alphas,
+        ))
+    }
+}
+
+impl NblastNeuron for ExactKiddoTangentsAlphas {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn points(&self) -> Vec<Point3> {
+        self.0.points()
+    }
+
+    fn tangents(&self) -> Vec<Normal3> {
+        self.0.tangents()
+    }
+
+    fn alphas(&self) -> Vec<Precision> {
+        self.0.alphas()
+    }
+}
+
+impl QueryNeuron for ExactKiddoTangentsAlphas {
+    fn query_dist_dots(&self, target: &impl TargetNeuron, use_alpha: bool) -> Vec<DistDot> {
+        self.0.query_dist_dots(target, use_alpha)
+    }
+
+    fn self_hit(&self, score_calc: &ScoreCalc, use_alpha: bool) -> Precision {
+        self.0.self_hit(score_calc, use_alpha)
+    }
+}
+
+impl TargetNeuron for ExactKiddoTangentsAlphas {
+    fn nearest_match_dist_dot(
+        &self,
+        point: &Point3,
+        tangent: &Normal3,
+        alpha: Option<Precision>,
+    ) -> DistDot {
+        self.0
+            .nearest_match_dist_dot_inner(point, tangent, alpha, true)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use fastrand::Rng;
+
+    fn random_points(n: usize, rng: &mut Rng) -> Vec<Point3> {
+        std::iter::repeat_with(|| [rng.f64(), rng.f64(), rng.f64()])
+            .take(n)
+            .collect()
+    }
+
+    #[test]
+    fn stable_index() {
+        let mut rng = Rng::with_seed(1991);
+        let pts = random_points(1000, &mut rng);
+        let tree = KdTree::new_from_slice(pts.as_slice());
+        for (exp_idx, pt) in pts.iter().enumerate() {
+            let stored_idx = tree.nearest_one::<SquaredEuclidean>(pt).item as usize;
+            assert_eq!(exp_idx, stored_idx)
+        }
+    }
+}

--- a/nblast-rs/src/neurons/kiddo.rs
+++ b/nblast-rs/src/neurons/kiddo.rs
@@ -10,6 +10,7 @@ type KdTree = ImmutableKdTree<Precision, 3>;
 /// Target neuron using a KDTree from the kiddo crate.
 ///
 /// By default, this uses approximate nearest neighbour for one-off lookups (as used in NBLAST scoring).
+/// However, in tests it is *very* approximate.
 /// See the [ExactKiddoTangentsAlphas] for exact 1NN.
 pub struct KiddoTangentsAlphas {
     tree: KdTree,

--- a/nblast-rs/src/neurons/mod.rs
+++ b/nblast-rs/src/neurons/mod.rs
@@ -3,7 +3,8 @@ use crate::{centroid, DistDot, Normal3, Point3, Precision, ScoreCalc, TangentAlp
 
 use self::rstar::RStarTangentsAlphas;
 
-// pub mod fnntw;
+#[cfg(feature = "kiddo")]
+pub mod kiddo;
 #[cfg(feature = "nabo")]
 pub mod nabo;
 pub mod rstar;

--- a/spatial_bench/Cargo.toml
+++ b/spatial_bench/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "spatial_bench"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bosque = "0.1.0"
+criterion = "0.5.1"
+csv = "1.3.0"
+fnntw = "0.4.1"
+nabo = "0.3.0"
+rstar = "0.11.0"
+
+[[bench]]
+name = "spatial"
+harness = false

--- a/spatial_bench/Cargo.toml
+++ b/spatial_bench/Cargo.toml
@@ -6,11 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bosque = "0.1.0"
+bosque = { git = "https://github.com/cavemanloverboy/bosque"}
 criterion = "0.5.1"
 csv = "1.3.0"
-fnntw = "0.4.1"
+fastrand = "2.0.1"
+kiddo = "4.0.0"
 nabo = "0.3.0"
+nalgebra = "0.32.3"
 rstar = "0.11.0"
 
 [[bench]]

--- a/spatial_bench/benches/spatial.rs
+++ b/spatial_bench/benches/spatial.rs
@@ -1,9 +1,78 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use spatial_bench as sb;
+use std::iter::repeat_with;
 
-pub fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("fib 20", |b| b.iter(|| fibonacci(black_box(20))));
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use fastrand::Rng;
+use spatial_bench::{
+    bosque::BosqueArena, kiddo::KiddoArena, nabo::NaboArena, read_augmented, rstar::RstarArena,
+    Point3, SpatialArena,
+};
+
+const N_NEURONS: usize = 1000;
+
+fn make_arena<S: SpatialArena>(pts: Vec<Vec<Point3>>) -> S {
+    let mut ar = S::default();
+    for p in pts.into_iter() {
+        ar.add_points(p);
+    }
+    ar
 }
 
-criterion_group!(benches, criterion_benchmark);
+fn random_pairs(max: usize, n: usize, rng: &mut Rng) -> Vec<(usize, usize)> {
+    repeat_with(|| (rng.usize(0..max), rng.usize(0..max)))
+        .take(n)
+        .collect()
+}
+
+fn pair_queries<S: SpatialArena>(arena: &S, pairs: &[(usize, usize)]) {
+    for (q, t) in pairs {
+        arena.query_target(*q, *t);
+    }
+}
+
+fn read_augmented_fixed() -> Vec<Vec<Point3>> {
+    let mut rng = fastrand::Rng::with_seed(1991);
+    read_augmented(N_NEURONS, &mut rng, 20.0, 1.0)
+}
+
+pub fn bench_construction(c: &mut Criterion) {
+    let points = read_augmented_fixed();
+
+    let mut group = c.benchmark_group("construction");
+    group.bench_function("bosque", |b| {
+        b.iter(|| black_box(make_arena::<BosqueArena>(points.clone())))
+    });
+    group.bench_function("kiddo", |b| {
+        b.iter(|| black_box(make_arena::<KiddoArena>(points.clone())))
+    });
+    group.bench_function("nabo", |b| {
+        b.iter(|| black_box(make_arena::<NaboArena>(points.clone())))
+    });
+    group.bench_function("rstar", |b| {
+        b.iter(|| black_box(make_arena::<RstarArena>(points.clone())))
+    });
+}
+
+pub fn bench_queries(c: &mut Criterion) {
+    let points = read_augmented_fixed();
+    let n_pairs = 1_000;
+    let mut rng = fastrand::Rng::with_seed(1991);
+    let pairs = random_pairs(points.len(), n_pairs, &mut rng);
+    let mut group = c.benchmark_group("pairwise query");
+
+    let ar = make_arena::<BosqueArena>(points.clone());
+    group.bench_function("bosque", |b| {
+        b.iter(|| black_box(pair_queries(&ar, &pairs)))
+    });
+
+    let ar = make_arena::<KiddoArena>(points.clone());
+    group.bench_function("kiddo", |b| b.iter(|| black_box(pair_queries(&ar, &pairs))));
+
+    let ar = make_arena::<NaboArena>(points.clone());
+    group.bench_function("nabo", |b| b.iter(|| black_box(pair_queries(&ar, &pairs))));
+
+    let ar = make_arena::<RstarArena>(points.clone());
+    group.bench_function("rstar", |b| b.iter(|| black_box(pair_queries(&ar, &pairs))));
+}
+
+criterion_group!(benches, bench_construction, bench_queries);
 criterion_main!(benches);

--- a/spatial_bench/benches/spatial.rs
+++ b/spatial_bench/benches/spatial.rs
@@ -1,0 +1,9 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use spatial_bench as sb;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("fib 20", |b| b.iter(|| fibonacci(black_box(20))));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/spatial_bench/src/bosque.rs
+++ b/spatial_bench/src/bosque.rs
@@ -1,0 +1,50 @@
+use crate::{Point3, Precision, SpatialArena};
+
+#[derive(Default)]
+pub struct BosqueArena {
+    trees: Vec<Vec<Point3>>,
+    idxs: Vec<Vec<usize>>,
+}
+
+impl SpatialArena for BosqueArena {
+    fn add_points(&mut self, mut p: Vec<Point3>) -> usize {
+        let mut idxs: Vec<_> = (0..(p.len() as u32)).collect();
+        bosque::tree::build_tree_with_indices(p.as_mut(), idxs.as_mut());
+        let idx = self.len();
+        self.trees.push(p);
+        self.idxs
+            .push(idxs.into_iter().map(|i| i as usize).collect());
+        idx
+    }
+
+    fn query_target(&self, q: usize, t: usize) -> Vec<(usize, Precision)> {
+        let tgt = self.trees.get(t).unwrap();
+        let tgt_idxs = self.idxs.get(t).unwrap();
+        self.trees
+            .get(q)
+            .unwrap()
+            .iter()
+            .map(|p| {
+                let (d, idx) = bosque::tree::nearest_one(tgt.as_slice(), p);
+                (tgt_idxs[idx], d)
+            })
+            .collect()
+    }
+
+    fn local_query(&self, q: usize, neighborhood: usize) -> Vec<Vec<usize>> {
+        let t = self.trees.get(q).unwrap();
+        let idxs = self.idxs.get(q).unwrap();
+        t.iter()
+            .map(|p| {
+                bosque::tree::nearest_k(t.as_slice(), p, neighborhood)
+                    .into_iter()
+                    .map(|(_d, i)| idxs[i])
+                    .collect()
+            })
+            .collect()
+    }
+
+    fn len(&self) -> usize {
+        self.trees.len()
+    }
+}

--- a/spatial_bench/src/kiddo.rs
+++ b/spatial_bench/src/kiddo.rs
@@ -1,0 +1,50 @@
+use kiddo::{ImmutableKdTree, SquaredEuclidean};
+
+use crate::{Point3, Precision, SpatialArena};
+
+#[derive(Default)]
+pub struct KiddoArena {
+    trees: Vec<ImmutableKdTree<Precision, 3>>,
+    points: Vec<Vec<Point3>>,
+}
+
+impl SpatialArena for KiddoArena {
+    fn add_points(&mut self, p: Vec<Point3>) -> usize {
+        let idx = self.len();
+        self.trees.push(p.as_slice().into());
+        self.points.push(p);
+        idx
+    }
+
+    fn query_target(&self, q: usize, t: usize) -> Vec<(usize, Precision)> {
+        let tgt = self.trees.get(t).unwrap();
+        self.points
+            .get(q)
+            .unwrap()
+            .iter()
+            .map(|p| {
+                let nn = tgt.nearest_one::<SquaredEuclidean>(p);
+                (nn.item as usize, nn.distance.sqrt())
+            })
+            .collect()
+    }
+
+    fn local_query(&self, q: usize, neighborhood: usize) -> Vec<Vec<usize>> {
+        let tgt = self.trees.get(q).unwrap();
+        self.points
+            .get(q)
+            .unwrap()
+            .iter()
+            .map(|p| {
+                tgt.nearest_n::<SquaredEuclidean>(p, neighborhood)
+                    .into_iter()
+                    .map(|nn| nn.item as usize)
+                    .collect()
+            })
+            .collect()
+    }
+
+    fn len(&self) -> usize {
+        self.trees.len()
+    }
+}

--- a/spatial_bench/src/lib.rs
+++ b/spatial_bench/src/lib.rs
@@ -103,11 +103,7 @@ pub trait SpatialArena: Default {
     fn all_v_all(&self) -> Vec<Vec<Vec<(usize, Precision)>>> {
         let len = self.len();
         (0..len)
-            .map(|q| {
-                (0..len)
-                    .map(move |t| self.query_target(q, t.clone()))
-                    .collect()
-            })
+            .map(|q| (0..len).map(move |t| self.query_target(q, t)).collect())
             .collect()
     }
 }

--- a/spatial_bench/src/lib.rs
+++ b/spatial_bench/src/lib.rs
@@ -1,5 +1,4 @@
 use fastrand::Rng;
-use std::collections::HashMap;
 use std::fs::File;
 use std::path::PathBuf;
 
@@ -36,8 +35,6 @@ const NAMES: [&str; 20] = [
     "GadMARCM-F000442_seg002",
     "GadMARCM-F000476_seg001",
 ];
-
-const N_NEIGHBORS: usize = 5;
 
 fn data_dir() -> PathBuf {
     // crate dir

--- a/spatial_bench/src/lib.rs
+++ b/spatial_bench/src/lib.rs
@@ -1,0 +1,77 @@
+use std::fs::File;
+use std::path::PathBuf;
+
+use csv::ReaderBuilder;
+
+pub type Precision = f64;
+pub type Point3 = [Precision; 3];
+
+const NAMES: [&str; 20] = [
+    "ChaMARCM-F000586_seg002",
+    "FruMARCM-F000085_seg001",
+    "FruMARCM-F000188_seg001",
+    "FruMARCM-F000270_seg001",
+    "FruMARCM-F000706_seg001",
+    "FruMARCM-F001115_seg002",
+    "FruMARCM-F001494_seg002",
+    "FruMARCM-F001929_seg001",
+    "FruMARCM-M000115_seg001",
+    "FruMARCM-M000842_seg002",
+    "FruMARCM-M001051_seg002",
+    "FruMARCM-M001205_seg002",
+    "FruMARCM-M001339_seg001",
+    "GadMARCM-F000050_seg001",
+    "GadMARCM-F000071_seg001",
+    "GadMARCM-F000122_seg001",
+    "GadMARCM-F000142_seg002",
+    "GadMARCM-F000423_seg001",
+    "GadMARCM-F000442_seg002",
+    "GadMARCM-F000476_seg001",
+];
+
+const N_NEIGHBORS: usize = 5;
+
+fn data_dir() -> PathBuf {
+    // crate dir
+    let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .canonicalize()
+        .expect("couldn't resolve");
+
+    // workspace dir
+    let has_parent = d.pop();
+
+    if !has_parent {
+        panic!("Couldn't find parent directory");
+    }
+
+    d.push("data");
+    d
+}
+
+fn to_path(name: &str) -> PathBuf {
+    let mut d = data_dir();
+    d.push("points");
+    d.push(format!("{}.csv", name));
+    d
+}
+
+type Record = (usize, f64, f64, f64);
+
+fn read_points(name: &str) -> Vec<Point3> {
+    let fpath = to_path(name);
+    let f =
+        File::open(fpath.clone()).unwrap_or_else(|_| panic!("couldn't find file at {:?}", fpath));
+    let mut reader = ReaderBuilder::new().has_headers(true).from_reader(f);
+    let mut out = Vec::default();
+
+    for result in reader.deserialize() {
+        let record: Record = result.expect("Could not deserialise");
+        out.push([record.1, record.2, record.3]);
+    }
+
+    out
+}
+
+fn read_all_points() -> Vec<Vec<Point3>> {
+    NAMES.iter().map(|n| read_points(n)).collect()
+}

--- a/spatial_bench/src/nabo.rs
+++ b/spatial_bench/src/nabo.rs
@@ -1,0 +1,92 @@
+use crate::{Point3, Precision, SpatialArena};
+use nabo::{KDTree, NotNan, Point};
+
+#[derive(Clone, Copy, Debug, Default)]
+struct NaboPointWithIndex {
+    pub point: [NotNan<Precision>; 3],
+    pub index: usize,
+}
+
+impl NaboPointWithIndex {
+    pub fn new(point: &Point3, index: usize) -> Self {
+        Self {
+            point: [
+                NotNan::new(point[0]).unwrap(),
+                NotNan::new(point[1]).unwrap(),
+                NotNan::new(point[2]).unwrap(),
+            ],
+            index,
+        }
+    }
+}
+
+impl From<NaboPointWithIndex> for Point3 {
+    fn from(p: NaboPointWithIndex) -> Self {
+        [*p.point[0], *p.point[1], *p.point[2]]
+    }
+}
+
+impl Point<Precision> for NaboPointWithIndex {
+    fn get(&self, i: u32) -> nabo::NotNan<Precision> {
+        self.point[i as usize]
+    }
+
+    fn set(&mut self, i: u32, value: nabo::NotNan<Precision>) {
+        self.point[i as usize] = value;
+    }
+
+    const DIM: u32 = 3;
+}
+
+#[derive(Default)]
+pub struct NaboArena {
+    trees: Vec<KDTree<Precision, NaboPointWithIndex>>,
+    points: Vec<Vec<NaboPointWithIndex>>,
+}
+
+impl SpatialArena for NaboArena {
+    fn add_points(&mut self, p: Vec<Point3>) -> usize {
+        let all_p: Vec<_> = p
+            .iter()
+            .enumerate()
+            .map(|(idx, p)| NaboPointWithIndex::new(p, idx))
+            .collect();
+        let t = KDTree::new(&all_p);
+        let idx = self.len();
+        self.trees.push(t);
+        self.points.push(all_p);
+        idx
+    }
+
+    fn query_target(&self, q: usize, t: usize) -> Vec<(usize, Precision)> {
+        let t_tree = self.trees.get(t).unwrap();
+        self.points
+            .get(q)
+            .unwrap()
+            .iter()
+            .map(|p| {
+                let n = t_tree.knn(1, p).pop().unwrap();
+                (n.point.index, n.dist2.sqrt())
+            })
+            .collect()
+    }
+
+    fn local_query(&self, q: usize, neighborhood: usize) -> Vec<Vec<usize>> {
+        let t = self.trees.get(q).unwrap();
+        self.points
+            .get(q)
+            .unwrap()
+            .iter()
+            .map(|p| {
+                t.knn(neighborhood as u32, p)
+                    .into_iter()
+                    .map(|n| n.point.index)
+                    .collect()
+            })
+            .collect()
+    }
+
+    fn len(&self) -> usize {
+        self.trees.len()
+    }
+}

--- a/spatial_bench/src/rstar.rs
+++ b/spatial_bench/src/rstar.rs
@@ -1,0 +1,55 @@
+use rstar::{primitives::GeomWithData, PointDistance, RTree};
+
+use crate::{Point3, Precision, SpatialArena};
+
+pub type RsPoint = GeomWithData<Point3, usize>;
+
+#[derive(Debug, Default)]
+pub struct RstarArena {
+    trees: Vec<rstar::RTree<RsPoint>>,
+}
+
+impl SpatialArena for RstarArena {
+    fn add_points(&mut self, p: Vec<Point3>) -> usize {
+        let t = RTree::bulk_load(
+            p.into_iter()
+                .enumerate()
+                .map(|(idx, p)| RsPoint::new(p, idx))
+                .collect(),
+        );
+        let idx = self.len();
+        self.trees.push(t);
+        idx
+    }
+
+    fn query_target(&self, q: usize, t: usize) -> Vec<(usize, Precision)> {
+        let t_tree = self.trees.get(t).unwrap();
+
+        self.trees
+            .get(q)
+            .unwrap()
+            .iter()
+            .map(|p| {
+                let neighb = t_tree.nearest_neighbor(p.geom()).unwrap();
+                let dist = p.distance_2(neighb.geom()).sqrt();
+                (p.data, dist)
+            })
+            .collect()
+    }
+
+    fn local_query(&self, q: usize, neighborhood: usize) -> Vec<Vec<usize>> {
+        let tree = self.trees.get(q).unwrap();
+        tree.iter()
+            .map(|p| {
+                tree.nearest_neighbor_iter(p.geom())
+                    .take(neighborhood)
+                    .map(|n| n.data)
+                    .collect()
+            })
+            .collect()
+    }
+
+    fn len(&self) -> usize {
+        self.trees.len()
+    }
+}


### PR DESCRIPTION
Crate for benchmarking various spatial lookup crates for our purposes.

Kiddo comes out on top, but will be easier to use once https://github.com/sdd/kiddo/pull/135 is merged. Note that there are some questions about using kiddo in wasm: https://github.com/sdd/kiddo/issues/130 

@schlegelp may find this useful! Just run `cargo bench` from the `spatial_bench` directory. For each of bosque (fastcore-rs default), kiddo, nabo, and rstar (nblast-rs default), it benchmarks building 1000 trees by augmenting the example data, and running just the spatial query bit of 1 000 000 neuron pair lookups. These are all in serial, I don't have a reason to suspect they'll parallelise differently.